### PR TITLE
Expand library and CLI surfaces of evix

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,18 +40,22 @@ copying path '/nix/store/jfdpyszsgvsnz68y36qi65irx7r6a52q-source' from 'https://
 
 <!--markdownlint-disable MD013-->
 
-| Flag                   | Description                                                     |
-| ---------------------- | --------------------------------------------------------------- |
-| `--flake REF`          | Evaluate a flake output                                         |
-| `--expr EXPR`          | Evaluate an inline Nix expression                               |
-| `--file PATH`          | Evaluate a Nix file                                             |
-| `--arg NAME EXPR`      | Pass a Nix expression argument                                  |
-| `--argstr NAME VALUE`  | Pass a string argument                                          |
-| `--workers N`          | Worker processes (default: 1)                                   |
-| `--max-memory-size MB` | Memory limit per worker; restarts when exceeded (default: 4096) |
-| `--force-recurse`      | Recurse into all attrsets, ignoring `recurseForDerivations`     |
-| `--gc-roots-dir DIR`   | Register GC root symlinks for evaluated derivations             |
-| `-v`, `--verbose`      | Increase logging verbosity (info -> debug -> trace)             |
+| Flag                        | Description                                                              |
+| --------------------------- | ------------------------------------------------------------------------ |
+| `--flake REF`               | Evaluate a flake output                                                  |
+| `--expr EXPR`               | Evaluate an inline Nix expression                                        |
+| `--file PATH`               | Evaluate a Nix file                                                      |
+| `--arg NAME EXPR`           | Pass a Nix expression argument                                           |
+| `--argstr NAME VALUE`       | Pass a string argument                                                   |
+| `--override-input NAME REF` | Override a flake input while locking (flake inputs only)                 |
+| `--option KEY VALUE`        | Set a Nix setting (e.g. `restrict-eval`, `allow-import-from-derivation`) |
+| `--meta`                    | Attach each derivation's `meta` attribute to the output                  |
+| `--show-input-drvs`         | Attach each derivation's input derivations (`inputDrvs`)                 |
+| `--workers N`               | Worker processes (default: 1)                                            |
+| `--max-memory-size MB`      | Memory limit per worker; restarts when exceeded (default: 4096)          |
+| `--force-recurse`           | Recurse into all attrsets, ignoring `recurseForDerivations`              |
+| `--gc-roots-dir DIR`        | Register GC root symlinks for evaluated derivations                      |
+| `-v`, `--verbose`           | Increase logging verbosity (info -> debug -> trace)                      |
 
 <!--markdownlint-enable MD013-->
 
@@ -73,6 +77,27 @@ Each line is a JSON object. Derivation attributes emit:
   "drvPath": "/nix/store/...",
   "outputs": { "out": "/nix/store/..." }
 }
+```
+
+With `--meta`, the derivation's `meta` attribute is attached verbatim as a
+`meta` object. With `--show-input-drvs`, input derivations are attached as
+`inputDrvs`, keyed by absolute `.drv` store path with their output-name lists:
+
+```json
+{
+  "attr": "hello",
+  "drvPath": "/nix/store/...-hello.drv",
+  "outputs": { "out": "/nix/store/...-hello" },
+  "meta": { "description": "...", "license": { "spdxId": "GPL-3.0-or-later" } },
+  "inputDrvs": { "/nix/store/...-stdenv-linux.drv": ["out"] }
+}
+```
+
+Aggregate jobs that declare `constituents` emit them as a list of attribute
+names:
+
+```json
+{ "attr": "release", "drvPath": "...", "constituents": ["hello", "world"] }
 ```
 
 Non-derivation attrsets emit child attribute names for further recursion:
@@ -114,6 +139,10 @@ let config = Config {
     gc_roots_dir: None,
     workers: 4,
     max_memory_size: 4096,
+    meta: false,
+    show_input_drvs: false,
+    override_inputs: vec![],
+    nix_options: vec![],
 };
 
 evix::evaluate(&config, |event| {

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -158,10 +158,16 @@ fn make_job(
     }))
 }
 
-/// Read a derivation's `meta` attribute as freeform JSON. Best-effort: returns
-/// `None` when the attribute is absent. Individual nested attributes that fail
-/// to force (functions, throwing values) are skipped rather than discarding the
-/// whole `meta` set.
+/// Convert a derivation's `meta` attribute to freeform JSON.
+///
+/// `meta` is informational and nixpkgs fields can fail to force (functions,
+/// `throw`), so unreadable nested attributes are dropped rather than failing the
+/// job. Such omissions are intentional and not logged.
+///
+/// # Returns
+///
+/// The `meta` attrset as a JSON object, or `None` if the derivation declares no
+/// `meta` attribute.
 fn read_meta(value: &Value<'_>) -> Option<serde_json::Value> {
     if !value.has_attr("meta").unwrap_or(false) {
         return None;
@@ -170,10 +176,12 @@ fn read_meta(value: &Value<'_>) -> Option<serde_json::Value> {
     value_to_json(meta)
 }
 
-/// Recursively convert a forced Nix value into JSON. Each node is forced to
-/// weak-head normal form on entry; nodes that fail to force, and value kinds
-/// without a JSON analogue (functions, external values), yield `None` so the
-/// caller can skip them.
+/// Recursively convert a Nix value to JSON, forcing each node on entry.
+///
+/// # Returns
+///
+/// The value as JSON, or `None` if the node fails to force or has no JSON
+/// analogue (thunks that error, functions, external values).
 fn value_to_json(mut value: Value<'_>) -> Option<serde_json::Value> {
     use serde_json::Value as J;
 
@@ -217,9 +225,12 @@ fn value_to_json(mut value: Value<'_>) -> Option<serde_json::Value> {
     }
 }
 
-/// Read the `constituents` attribute of an aggregate (Hydra) job as a list of
-/// attribute-path strings. Returns `None` for ordinary derivations that do not
-/// declare the attribute.
+/// Read the `constituents` attribute of an aggregate (Hydra) job.
+///
+/// # Returns
+///
+/// The constituent attribute-path strings, or `None` when the derivation does
+/// not declare `constituents` (an ordinary, non-aggregate job).
 fn read_constituents(value: &Value<'_>) -> Option<Vec<String>> {
     if !value.has_attr("constituents").unwrap_or(false) {
         return None;
@@ -238,19 +249,39 @@ fn read_constituents(value: &Value<'_>) -> Option<Vec<String>> {
     Some(out)
 }
 
-/// Read a derivation's input derivations by parsing the `.drv` file's JSON
-/// representation. Keyed by input `.drv` store path. Best-effort: returns an
-/// empty map when the derivation cannot be read or serialized.
+/// Read a derivation's input derivations from its `.drv` file.
+///
+/// Unlike `meta`, missing `inputDrvs` has downstream consequences (consumers use
+/// it to discover build dependencies), so each failure is logged at `warn`
+/// rather than swallowed silently.
+///
+/// # Returns
+///
+/// A map from absolute input `.drv` store path to that input's output-name list.
+/// Empty when the derivation has no input derivations, or when it cannot be
+/// read, serialized, or parsed (each of those failures is logged).
 fn read_input_drvs(store: &Store, drv_path: &StorePath) -> BTreeMap<String, serde_json::Value> {
     let mut map = BTreeMap::new();
-    let Ok(drv) = store.read_derivation(drv_path) else {
-        return map;
+    let drv = match store.read_derivation(drv_path) {
+        Ok(drv) => drv,
+        Err(e) => {
+            warn!(error = %e, "failed to read derivation for inputDrvs");
+            return map;
+        }
     };
-    let Ok(json) = drv.to_json() else {
-        return map;
+    let json = match drv.to_json() {
+        Ok(json) => json,
+        Err(e) => {
+            warn!(error = %e, "failed to serialize derivation for inputDrvs");
+            return map;
+        }
     };
-    let Ok(parsed) = serde_json::from_str::<serde_json::Value>(&json) else {
-        return map;
+    let parsed = match serde_json::from_str::<serde_json::Value>(&json) {
+        Ok(parsed) => parsed,
+        Err(e) => {
+            warn!(error = %e, "failed to parse derivation JSON for inputDrvs");
+            return map;
+        }
     };
     // `nix_derivation_to_json` nests input derivations under `inputs.drvs` and
     // keys them by store-relative basename. Re-add the store prefix so keys are
@@ -259,6 +290,8 @@ fn read_input_drvs(store: &Store, drv_path: &StorePath) -> BTreeMap<String, serd
     let store_dir = store
         .store_dir()
         .unwrap_or_else(|_| "/nix/store".to_string());
+    // A derivation with no input derivations (e.g. a fixed-output fetch) legitimately
+    // has no `inputs.drvs`, so an absent key is normal and not logged.
     let Some(drvs) = parsed
         .get("inputs")
         .and_then(|inputs| inputs.get("drvs"))
@@ -302,9 +335,16 @@ fn output_paths(value: &Value<'_>) -> BTreeMap<String, Option<String>> {
     map
 }
 
-/// Resolve the store path of a single output. Each output is exposed on the
-/// derivation as an attribute whose `outPath` is the store path; fall back to
-/// coercing the attribute directly for non-standard derivations.
+/// Resolve the store path of a single named output.
+///
+/// Each output is exposed on the derivation as an attribute whose `outPath` is
+/// the store path; for non-standard derivations the attribute is coerced
+/// directly as a string or path.
+///
+/// # Returns
+///
+/// The output's store path, or `None` if the output attribute is missing or
+/// cannot be coerced to a path.
 fn output_path_for(value: &Value<'_>, name: &str) -> Option<String> {
     let out = value.get_attr(name).ok()?;
     if let Ok(path) = out.get_attr("outPath").and_then(|v| v.as_string()) {

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeMap;
 
 use anyhow::{Context as _, Result};
-use nix_bindings::{EvalState, Store, Value, ValueType};
+use nix_bindings::{EvalState, Store, StorePath, Value, ValueType};
 use tracing::{debug, warn};
 
 use crate::{Config, EvalError, Event};
@@ -127,6 +127,14 @@ fn make_job(
         .unwrap_or_default();
     let outputs = output_paths(value);
 
+    let meta = if config.meta { read_meta(value) } else { None };
+    let constituents = read_constituents(value);
+    let input_drvs = if config.show_input_drvs {
+        read_input_drvs(store, &drv_path)
+    } else {
+        BTreeMap::new()
+    };
+
     let gc_root_error = config.gc_roots_dir.as_ref().and_then(|dir| {
         register_gc_root(dir, &drv_path_str).err().map(|e| {
             warn!(drv_path = %drv_path_str, error = %e, "failed to register gc root");
@@ -143,8 +151,134 @@ fn make_job(
         system,
         drv_path: drv_path_str,
         outputs,
+        meta,
+        input_drvs,
+        constituents,
         gc_root_error,
     }))
+}
+
+/// Read a derivation's `meta` attribute as freeform JSON. Best-effort: returns
+/// `None` when the attribute is absent. Individual nested attributes that fail
+/// to force (functions, throwing values) are skipped rather than discarding the
+/// whole `meta` set.
+fn read_meta(value: &Value<'_>) -> Option<serde_json::Value> {
+    if !value.has_attr("meta").unwrap_or(false) {
+        return None;
+    }
+    let meta = value.get_attr("meta").ok()?;
+    value_to_json(meta)
+}
+
+/// Recursively convert a forced Nix value into JSON. Each node is forced to
+/// weak-head normal form on entry; nodes that fail to force, and value kinds
+/// without a JSON analogue (functions, external values), yield `None` so the
+/// caller can skip them.
+fn value_to_json(mut value: Value<'_>) -> Option<serde_json::Value> {
+    use serde_json::Value as J;
+
+    value.force().ok()?;
+    match value.value_type() {
+        ValueType::Null => Some(J::Null),
+        ValueType::Bool => value.as_bool().ok().map(J::Bool),
+        ValueType::Int => value.as_int().ok().map(|i| J::Number(i.into())),
+        ValueType::Float => value
+            .as_float()
+            .ok()
+            .and_then(serde_json::Number::from_f64)
+            .map(J::Number),
+        ValueType::String => value.as_string().ok().map(J::String),
+        ValueType::Path => value
+            .as_path()
+            .ok()
+            .map(|p| J::String(p.to_string_lossy().into_owned())),
+        ValueType::List => {
+            let len = value.list_len().ok()?;
+            let mut arr = Vec::with_capacity(len);
+            for i in 0..len {
+                let item = value.list_get(i).ok()?;
+                arr.push(value_to_json(item).unwrap_or(J::Null));
+            }
+            Some(J::Array(arr))
+        }
+        ValueType::Attrs => {
+            let keys = value.attr_keys().ok()?;
+            let mut map = serde_json::Map::new();
+            for key in keys {
+                if let Ok(child) = value.get_attr(&key)
+                    && let Some(child_json) = value_to_json(child)
+                {
+                    map.insert(key, child_json);
+                }
+            }
+            Some(J::Object(map))
+        }
+        ValueType::Thunk | ValueType::Function | ValueType::External => None,
+    }
+}
+
+/// Read the `constituents` attribute of an aggregate (Hydra) job as a list of
+/// attribute-path strings. Returns `None` for ordinary derivations that do not
+/// declare the attribute.
+fn read_constituents(value: &Value<'_>) -> Option<Vec<String>> {
+    if !value.has_attr("constituents").unwrap_or(false) {
+        return None;
+    }
+    let mut list = value.get_attr("constituents").ok()?;
+    list.force().ok()?;
+    let len = list.list_len().ok()?;
+    let mut out = Vec::with_capacity(len);
+    for i in 0..len {
+        if let Ok(item) = list.list_get(i)
+            && let Ok(s) = item.as_string()
+        {
+            out.push(s);
+        }
+    }
+    Some(out)
+}
+
+/// Read a derivation's input derivations by parsing the `.drv` file's JSON
+/// representation. Keyed by input `.drv` store path. Best-effort: returns an
+/// empty map when the derivation cannot be read or serialized.
+fn read_input_drvs(store: &Store, drv_path: &StorePath) -> BTreeMap<String, serde_json::Value> {
+    let mut map = BTreeMap::new();
+    let Ok(drv) = store.read_derivation(drv_path) else {
+        return map;
+    };
+    let Ok(json) = drv.to_json() else {
+        return map;
+    };
+    let Ok(parsed) = serde_json::from_str::<serde_json::Value>(&json) else {
+        return map;
+    };
+    // `nix_derivation_to_json` nests input derivations under `inputs.drvs` and
+    // keys them by store-relative basename. Re-add the store prefix so keys are
+    // absolute `.drv` paths, and expose the value as the output-name list to
+    // match the `nix-eval-jobs` `inputDrvs` contract (`{drv: ["out", ...]}`).
+    let store_dir = store
+        .store_dir()
+        .unwrap_or_else(|_| "/nix/store".to_string());
+    let Some(drvs) = parsed
+        .get("inputs")
+        .and_then(|inputs| inputs.get("drvs"))
+        .and_then(serde_json::Value::as_object)
+    else {
+        return map;
+    };
+    for (key, value) in drvs {
+        let full_path = if key.starts_with('/') {
+            key.clone()
+        } else {
+            format!("{store_dir}/{key}")
+        };
+        let outputs = value
+            .get("outputs")
+            .cloned()
+            .unwrap_or_else(|| value.clone());
+        map.insert(full_path, outputs);
+    }
+    map
 }
 
 fn output_paths(value: &Value<'_>) -> BTreeMap<String, Option<String>> {
@@ -162,14 +296,24 @@ fn output_paths(value: &Value<'_>) -> BTreeMap<String, Option<String>> {
         let Ok(name) = name_val.as_string() else {
             continue;
         };
-        let path = value.get_attr(&name).ok().and_then(|out| {
-            out.as_string()
-                .ok()
-                .or_else(|| out.as_path().map(|p| p.to_string_lossy().into_owned()).ok())
-        });
+        let path = output_path_for(value, &name);
         map.insert(name, path);
     }
     map
+}
+
+/// Resolve the store path of a single output. Each output is exposed on the
+/// derivation as an attribute whose `outPath` is the store path; fall back to
+/// coercing the attribute directly for non-standard derivations.
+fn output_path_for(value: &Value<'_>, name: &str) -> Option<String> {
+    let out = value.get_attr(name).ok()?;
+    if let Ok(path) = out.get_attr("outPath").and_then(|v| v.as_string()) {
+        return Some(path);
+    }
+    if let Ok(s) = out.as_string() {
+        return Some(s);
+    }
+    out.as_path().ok().map(|p| p.to_string_lossy().into_owned())
 }
 
 fn register_gc_root(gc_dir: &std::path::Path, drv_path: &str) -> Result<()> {

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -173,7 +173,7 @@ fn read_meta(value: &Value<'_>) -> Option<serde_json::Value> {
         return None;
     }
     let meta = value.get_attr("meta").ok()?;
-    value_to_json(meta)
+    value_to_json(meta, 64)
 }
 
 /// Recursively convert a Nix value to JSON, forcing each node on entry.
@@ -182,8 +182,12 @@ fn read_meta(value: &Value<'_>) -> Option<serde_json::Value> {
 ///
 /// The value as JSON, or `None` if the node fails to force or has no JSON
 /// analogue (thunks that error, functions, external values).
-fn value_to_json(mut value: Value<'_>) -> Option<serde_json::Value> {
+fn value_to_json(mut value: Value<'_>, depth_remaining: u32) -> Option<serde_json::Value> {
     use serde_json::Value as J;
+
+    if depth_remaining == 0 {
+        return None;
+    }
 
     value.force().ok()?;
     match value.value_type() {
@@ -205,7 +209,7 @@ fn value_to_json(mut value: Value<'_>) -> Option<serde_json::Value> {
             let mut arr = Vec::with_capacity(len);
             for i in 0..len {
                 let item = value.list_get(i).ok()?;
-                arr.push(value_to_json(item).unwrap_or(J::Null));
+                arr.push(value_to_json(item, depth_remaining - 1).unwrap_or(J::Null));
             }
             Some(J::Array(arr))
         }
@@ -214,7 +218,7 @@ fn value_to_json(mut value: Value<'_>) -> Option<serde_json::Value> {
             let mut map = serde_json::Map::new();
             for key in keys {
                 if let Ok(child) = value.get_attr(&key)
-                    && let Some(child_json) = value_to_json(child)
+                    && let Some(child_json) = value_to_json(child, depth_remaining - 1)
                 {
                     map.insert(key, child_json);
                 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,12 +53,12 @@ pub struct Config {
     #[serde(default)]
     pub show_input_drvs: bool,
     /// Flake input overrides applied while locking, as `(input_path, ref)`
-    /// pairs (e.g. `("nixpkgs", "github:NixOS/nixpkgs/nixos-unstable")`). Only
+    /// pairs (e.g., `("nixpkgs", "github:NixOS/nixpkgs/nixos-unstable")`). Only
     /// meaningful for [`Input::Flake`].
     #[serde(default)]
     pub override_inputs: Vec<(String, String)>,
     /// Nix settings applied to the evaluation context before the eval state is
-    /// built, as `(key, value)` pairs (e.g.
+    /// built, as `(key, value)` pairs (e.g.,
     /// `("allow-import-from-derivation", "false")`). Equivalent to `nix`'s
     /// `--option KEY VALUE`.
     #[serde(default)]
@@ -79,8 +79,8 @@ pub struct Derivation {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub meta: Option<serde_json::Value>,
     /// Input derivations keyed by `.drv` store path, present only when
-    /// [`Config::show_input_drvs`] is set. The value mirrors the `inputDrvs`
-    /// entry from the derivation's JSON (typically `{"outputs": [...]}`).
+    /// [`Config::show_input_drvs`] is set. The value is the output-name list for
+    /// that derivation input (e.g., `["out"]`).
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub input_drvs: BTreeMap<String, serde_json::Value>,
     /// Constituent attribute names for an aggregate job (Hydra

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -169,12 +169,15 @@ where
 
 /// Like [`evaluate`], but observes a cancellation flag.
 ///
-/// When `cancel` is set to `true` the master stops dispatching new work, signals
-/// its workers to exit, and returns `Ok(())` once they have wound down. A worker
-/// already evaluating a single attribute runs to the end of that attribute
-/// before observing the request, so cancellation is cooperative rather than an
-/// immediate hard kill. This lets a caller enforce a wall-clock timeout without
-/// leaking worker processes.
+/// Setting `cancel` makes the master stop dispatching work and tell its workers
+/// to exit. Cancellation is cooperative: a worker already evaluating an
+/// attribute finishes it before observing the request, so a caller can enforce a
+/// wall-clock timeout without leaking worker processes.
+///
+/// # Errors
+///
+/// Returns an error if a worker reports a fatal evaluation error, if a worker
+/// process fails unexpectedly, or if `sink` returns an error.
 pub fn evaluate_cancellable<F>(
     config: &Config,
     cancel: &Arc<AtomicBool>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 use std::collections::BTreeMap;
 use std::path::PathBuf;
+use std::sync::atomic::AtomicBool;
 use std::sync::{Arc, Mutex};
 
 use anyhow::Context as _;
@@ -41,6 +42,27 @@ pub struct Config {
     pub gc_roots_dir: Option<PathBuf>,
     pub workers: usize,
     pub max_memory_size: usize,
+    /// Attach each derivation's `meta` attribute (description, license,
+    /// homepage, maintainers, ...) to the emitted [`Derivation`]. Off by
+    /// default because forcing `meta` deeply costs extra evaluation.
+    #[serde(default)]
+    pub meta: bool,
+    /// Read each derivation's input derivations from the store and attach them
+    /// as [`Derivation::input_drvs`]. Off by default because it reads the
+    /// `.drv` file for every job.
+    #[serde(default)]
+    pub show_input_drvs: bool,
+    /// Flake input overrides applied while locking, as `(input_path, ref)`
+    /// pairs (e.g. `("nixpkgs", "github:NixOS/nixpkgs/nixos-unstable")`). Only
+    /// meaningful for [`Input::Flake`].
+    #[serde(default)]
+    pub override_inputs: Vec<(String, String)>,
+    /// Nix settings applied to the evaluation context before the eval state is
+    /// built, as `(key, value)` pairs (e.g.
+    /// `("allow-import-from-derivation", "false")`). Equivalent to `nix`'s
+    /// `--option KEY VALUE`.
+    #[serde(default)]
+    pub nix_options: Vec<(String, String)>,
 }
 
 /// A derivation emitted by evaluation.
@@ -52,6 +74,19 @@ pub struct Derivation {
     pub system: String,
     pub drv_path: String,
     pub outputs: BTreeMap<String, Option<String>>,
+    /// The derivation's `meta` attribute as freeform JSON, present only when
+    /// [`Config::meta`] is set and the attribute exists.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub meta: Option<serde_json::Value>,
+    /// Input derivations keyed by `.drv` store path, present only when
+    /// [`Config::show_input_drvs`] is set. The value mirrors the `inputDrvs`
+    /// entry from the derivation's JSON (typically `{"outputs": [...]}`).
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub input_drvs: BTreeMap<String, serde_json::Value>,
+    /// Constituent attribute names for an aggregate job (Hydra
+    /// `constituents`), present only when the derivation declares them.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub constituents: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub gc_root_error: Option<String>,
 }
@@ -114,6 +149,10 @@ impl Event {
 ///     gc_roots_dir: None,
 ///     workers: 4,
 ///     max_memory_size: 4096,
+///     meta: false,
+///     show_input_drvs: false,
+///     override_inputs: vec![],
+///     nix_options: vec![],
 /// };
 ///
 /// evix::evaluate(&config, |event| {
@@ -125,6 +164,25 @@ pub fn evaluate<F>(config: &Config, sink: F) -> anyhow::Result<()>
 where
     F: FnMut(&Event) -> anyhow::Result<()> + Send + 'static,
 {
+    evaluate_cancellable(config, &Arc::new(AtomicBool::new(false)), sink)
+}
+
+/// Like [`evaluate`], but observes a cancellation flag.
+///
+/// When `cancel` is set to `true` the master stops dispatching new work, signals
+/// its workers to exit, and returns `Ok(())` once they have wound down. A worker
+/// already evaluating a single attribute runs to the end of that attribute
+/// before observing the request, so cancellation is cooperative rather than an
+/// immediate hard kill. This lets a caller enforce a wall-clock timeout without
+/// leaking worker processes.
+pub fn evaluate_cancellable<F>(
+    config: &Config,
+    cancel: &Arc<AtomicBool>,
+    sink: F,
+) -> anyhow::Result<()>
+where
+    F: FnMut(&Event) -> anyhow::Result<()> + Send + 'static,
+{
     debug!("evaluating input, {} workers", config.workers);
 
     if let Some(dir) = &config.gc_roots_dir {
@@ -133,7 +191,7 @@ where
     }
 
     let sink = Arc::new(Mutex::new(sink));
-    master::run(config, sink)
+    master::run(config, cancel, sink)
 }
 
 /// Worker entrypoint.

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,6 +33,22 @@ struct Args {
     #[pound(long)]
     argstr: Vec<String>,
 
+    /// Override a flake input (`--override-input NAME --override-input REF` pairs).
+    #[pound(long)]
+    override_input: Vec<String>,
+
+    /// Set a Nix setting (`--option KEY --option VALUE` pairs).
+    #[pound(long)]
+    option: Vec<String>,
+
+    /// Attach each derivation's `meta` attribute to the output.
+    #[pound(long)]
+    meta: bool,
+
+    /// Attach each derivation's input derivations (`inputDrvs`) to the output.
+    #[pound(long)]
+    show_input_drvs: bool,
+
     /// Number of worker processes.
     #[pound(long, default = "1")]
     workers: usize,
@@ -84,6 +100,28 @@ impl Args {
             auto_args.push((name.clone(), AutoArg::Str(value.clone())));
         }
 
+        let mut override_inputs = Vec::new();
+        for chunk in self.override_input.chunks(2) {
+            let [name, value] = chunk else {
+                eprintln!(
+                    "--override-input requires paired NAME REF values: use --override-input NAME --override-input REF"
+                );
+                process::exit(2);
+            };
+            override_inputs.push((name.clone(), value.clone()));
+        }
+
+        let mut nix_options = Vec::new();
+        for chunk in self.option.chunks(2) {
+            let [key, value] = chunk else {
+                eprintln!(
+                    "--option requires paired KEY VALUE values: use --option KEY --option VALUE"
+                );
+                process::exit(2);
+            };
+            nix_options.push((key.clone(), value.clone()));
+        }
+
         Config {
             input,
             auto_args,
@@ -91,6 +129,10 @@ impl Args {
             gc_roots_dir: self.gc_roots_dir.clone(),
             workers: self.workers,
             max_memory_size: self.max_memory_size,
+            meta: self.meta,
+            show_input_drvs: self.show_input_drvs,
+            override_inputs,
+            nix_options,
         }
     }
 
@@ -152,14 +194,24 @@ fn format_event(event: &Event) -> String {
                     v.as_ref().map_or(Json::Null, |p| Json::String(p.clone())),
                 );
             }
-            json!({
-                "attr": d.attr,
-                "attrPath": d.attr_path,
-                "name": d.name,
-                "system": d.system,
-                "drvPath": d.drv_path,
-                "outputs": outputs,
-            })
+            let mut obj = Map::new();
+            obj.insert("attr".into(), json!(d.attr));
+            obj.insert("attrPath".into(), json!(d.attr_path));
+            obj.insert("name".into(), json!(d.name));
+            obj.insert("system".into(), json!(d.system));
+            obj.insert("drvPath".into(), json!(d.drv_path));
+            obj.insert("outputs".into(), Json::Object(outputs));
+            if let Some(meta) = &d.meta {
+                obj.insert("meta".into(), meta.clone());
+            }
+            if !d.input_drvs.is_empty() {
+                let drvs: Map<String, Json> = d.input_drvs.clone().into_iter().collect();
+                obj.insert("inputDrvs".into(), Json::Object(drvs));
+            }
+            if let Some(constituents) = &d.constituents {
+                obj.insert("constituents".into(), json!(constituents));
+            }
+            Json::Object(obj)
         }
         Event::AttrSet {
             attr,

--- a/src/master.rs
+++ b/src/master.rs
@@ -83,6 +83,7 @@ where
                 if cancel.load(Ordering::Relaxed) {
                     writeln!(child_stdin, "exit")?;
                     child_stdin.flush()?;
+                    let _ = proc.wait();
                     info!("cancellation requested, collector exiting");
                     return Ok(());
                 }
@@ -102,6 +103,7 @@ where
                 if s.active == 0 {
                     writeln!(child_stdin, "exit")?;
                     child_stdin.flush()?;
+                    let _ = proc.wait();
                     info!("evaluation queue empty, exiting worker");
                     return Ok(());
                 }

--- a/src/master.rs
+++ b/src/master.rs
@@ -2,8 +2,12 @@ use std::{
     env, io,
     io::{BufRead, BufReader, Write},
     process::{Child, Command, Stdio},
-    sync::{Arc, Condvar, Mutex},
+    sync::{
+        Arc, Condvar, Mutex,
+        atomic::{AtomicBool, Ordering},
+    },
     thread,
+    time::Duration,
 };
 
 use anyhow::{Context as _, Result, bail};
@@ -11,13 +15,17 @@ use tracing::{debug, error, info, trace};
 
 use crate::{Config, EvalError, Event, WORKER_ENV};
 
+/// How often a collector parked waiting for work re-checks the cancellation
+/// flag.
+const CANCEL_POLL_INTERVAL: Duration = Duration::from_millis(200);
+
 struct SharedState {
     todo: Vec<Vec<String>>,
     active: usize,
     error: Option<String>,
 }
 
-pub fn run<F>(config: &Config, sink: Arc<Mutex<F>>) -> Result<()>
+pub fn run<F>(config: &Config, cancel: &Arc<AtomicBool>, sink: Arc<Mutex<F>>) -> Result<()>
 where
     F: FnMut(&Event) -> Result<()> + Send + 'static,
 {
@@ -35,8 +43,11 @@ where
     for _ in 0..n {
         let shared = Arc::clone(&shared);
         let sink = Arc::clone(&sink);
+        let cancel = Arc::clone(cancel);
         let config = config.clone();
-        handles.push(thread::spawn(move || collector(&config, shared, sink)));
+        handles.push(thread::spawn(move || {
+            collector(&config, &cancel, shared, sink)
+        }));
     }
 
     for h in handles {
@@ -54,6 +65,7 @@ where
 
 fn collector<F>(
     config: &Config,
+    cancel: &Arc<AtomicBool>,
     shared: Arc<(Mutex<SharedState>, Condvar)>,
     sink: Arc<Mutex<F>>,
 ) -> Result<()>
@@ -68,6 +80,12 @@ where
         let path = {
             let mut s = lock.lock().unwrap();
             loop {
+                if cancel.load(Ordering::Relaxed) {
+                    writeln!(child_stdin, "exit")?;
+                    child_stdin.flush()?;
+                    info!("cancellation requested, collector exiting");
+                    return Ok(());
+                }
                 if let Some(ref e) = s.error {
                     let msg = e.clone();
                     writeln!(child_stdin, "exit")?;
@@ -87,7 +105,10 @@ where
                     info!("evaluation queue empty, exiting worker");
                     return Ok(());
                 }
-                s = cvar.wait(s).unwrap();
+                // Park until new work arrives, but wake periodically so a
+                // cancellation request is observed even when no events flow.
+                let (guard, _timeout) = cvar.wait_timeout(s, CANCEL_POLL_INTERVAL).unwrap();
+                s = guard;
             }
         };
 

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -14,6 +14,12 @@ pub fn run() -> Result<()> {
     let config = read_config()?;
     debug!("worker initialized");
 
+    // Apply Nix settings through NIX_CONFIG before the context loads its
+    // configuration. `nix_setting_set` throws C++ exceptions that unwind across
+    // the FFI boundary and abort the process, so we go through the environment,
+    // which Nix reads when the context initializes.
+    apply_nix_options(&config.nix_options);
+
     let ctx = Arc::new(Context::new().context("Nix context")?);
     let store = Arc::new(Store::open(&ctx, None).context("Nix store")?);
     let state = build_eval_state(&ctx, &store, &config)?;
@@ -70,6 +76,28 @@ pub fn run() -> Result<()> {
     Ok(())
 }
 
+/// Merge `(key, value)` Nix settings into the `NIX_CONFIG` environment variable
+/// so they are picked up when the Nix context initializes. Existing
+/// `NIX_CONFIG` content is preserved and appended to.
+fn apply_nix_options(options: &[(String, String)]) {
+    if options.is_empty() {
+        return;
+    }
+    let mut config = std::env::var("NIX_CONFIG").unwrap_or_default();
+    for (key, value) in options {
+        if !config.is_empty() && !config.ends_with('\n') {
+            config.push('\n');
+        }
+        config.push_str(key);
+        config.push_str(" = ");
+        config.push_str(value);
+    }
+    // SAFETY: called once at worker startup, before any threads are spawned.
+    unsafe {
+        std::env::set_var("NIX_CONFIG", config);
+    }
+}
+
 fn read_config() -> Result<Config> {
     let mut line = String::new();
     if std::io::stdin().lock().read_line(&mut line)? == 0 {
@@ -100,7 +128,7 @@ fn eval_root<'s>(
     auto_args: Option<&Value<'s>>,
 ) -> Result<Value<'s>> {
     match &config.input {
-        Input::Flake(flake_ref) => eval_flake(ctx, state, flake_ref),
+        Input::Flake(flake_ref) => eval_flake(ctx, state, flake_ref, &config.override_inputs),
         Input::Expr(expr) => {
             let v = state
                 .eval_from_string(expr, "<cmdline>")
@@ -120,6 +148,7 @@ fn eval_flake<'s>(
     ctx: &Arc<Context>,
     state: &'s EvalState,
     flake_ref_str: &str,
+    override_inputs: &[(String, String)],
 ) -> Result<Value<'s>> {
     use nix_bindings::flake::{
         FetchersSettings, FlakeReference, FlakeReferenceParseFlags, LockFlags, LockedFlake,
@@ -134,7 +163,15 @@ fn eval_flake<'s>(
         FlakeReference::parse(ctx, &fetchers, &flake_settings, &parse_flags, flake_ref_str)
             .context("parsing flake reference")?;
 
-    let lock_flags = LockFlags::new(ctx, &flake_settings).context("lock flags")?;
+    let mut lock_flags = LockFlags::new(ctx, &flake_settings).context("lock flags")?;
+    for (name, value) in override_inputs {
+        let (override_ref, _fragment) =
+            FlakeReference::parse(ctx, &fetchers, &flake_settings, &parse_flags, value)
+                .with_context(|| format!("parsing --override-input {name} reference {value:?}"))?;
+        lock_flags = lock_flags
+            .add_input_override(name, &override_ref)
+            .with_context(|| format!("applying --override-input {name}"))?;
+    }
     let locked = LockedFlake::lock(
         ctx,
         &fetchers,


### PR DESCRIPTION
Adds some new CLI and config fields to include include derivation metadata, input derivations, and aggregate constituents in the output as well as the ability to pass Nix options and flake input overrides. Also adds a cooperative cancellation mechanism for evaluation.

Primarily the compatibility surfaces for nix-eval-jobs to replace it with evix in circus. This makes evix a bit more flexible for more "advanced" use cases (not like the old version was not flexible) but I think it's in a good state to put in circus now, now that we have improved introspection of derivation details, and provide safer evaluation control.