### PR TITLE
Better error handling, bounded streams & library cleanup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -282,6 +282,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -328,6 +329,7 @@ dependencies = [
  "futures-core",
  "futures-io",
  "futures-macro",
+ "futures-sink",
  "futures-task",
  "memchr",
  "pin-project-lite",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,9 +22,9 @@ capnp = "0.26.0"
 capnp-futures = "0.26.0"
 capnpc = "0.26.0"
 color-eyre = { version = "0.6.5", default-features = false }
-futures-channel = "0.3.32"
+futures-channel = { version = "0.3.32", features = [ "sink" ] }
 futures-core = "0.3.32"
-futures-util = "0.3.32"
+futures-util = { version = "0.3.32", features = [ "sink" ] }
 libc = "0.2.186"
 nix-bindings = { version = "0.2347.5", features = [ "full" ] }
 notify = "8.2.0"

--- a/README.md
+++ b/README.md
@@ -334,11 +334,24 @@ Evaluation errors are events too. They are non-fatal unless `fatal` is `true`:
 
 ## Library Usage
 
-Use `evix::Session` when embedding Evix in another Rust service:
+Use `evix::Session` when embedding Evix in another Rust service. Call
+`run_worker_if_requested` before starting the host application so Evix worker
+subprocesses enter the worker protocol after re-exec:
 
 ```rust
-use evix::{Config, Filter, Input, Session};
+use evix::{Config, Filter, Input, Session, run_worker_if_requested};
 use futures_util::StreamExt;
+
+fn main() -> anyhow::Result<()> {
+    if run_worker_if_requested()? {
+        return Ok(());
+    }
+
+    tokio::runtime::Builder::new_current_thread()
+        .enable_io()
+        .build()?
+        .block_on(example())
+}
 
 async fn example() -> anyhow::Result<()> {
     let config = Config {
@@ -369,10 +382,6 @@ async fn example() -> anyhow::Result<()> {
 `Session::stream` is single-use. Drain it once to populate the warm graph before
 calling `query_snapshot` or `diff_once`; `Session::watch` can start and drain
 the initial evaluation itself before emitting diffs.
-
-If your binary re-executes itself to host workers, check `evix::WORKER_ENV` on
-startup and call `evix::run_worker()` when it is set. The `evix` CLI does this
-already.
 
 ## Hacking
 

--- a/README.md
+++ b/README.md
@@ -383,6 +383,11 @@ async fn example() -> anyhow::Result<()> {
 calling `query_snapshot` or `diff_once`; `Session::watch` can start and drain
 the initial evaluation itself before emitting diffs.
 
+Use `Session::stream_bounded(capacity)` or `Session::watch_bounded(capacity)`
+when the embedding application needs backpressure. These variants keep at most
+`capacity` pending results, with `0` treated as `1`, and pause delivery while
+the receiver catches up.
+
 Serializing `evix::Event` directly with serde preserves the Rust enum shape,
 such as `{ "derivation": { ... } }` or `{ "attr_set": { ... } }`. Use
 `evix::json::event_value` or `evix::json::event_line` when you want the

--- a/README.md
+++ b/README.md
@@ -383,6 +383,11 @@ async fn example() -> anyhow::Result<()> {
 calling `query_snapshot` or `diff_once`; `Session::watch` can start and drain
 the initial evaluation itself before emitting diffs.
 
+Serializing `evix::Event` directly with serde preserves the Rust enum shape,
+such as `{ "derivation": { ... } }` or `{ "attr_set": { ... } }`. Use
+`evix::json::event_value` or `evix::json::event_line` when you want the
+flattened CLI-compatible NDJSON shape shown above.
+
 ## Hacking
 
 Evix is built with the latest stable Rust, targeting the 2024 edition. Those

--- a/README.md
+++ b/README.md
@@ -388,6 +388,12 @@ when the embedding application needs backpressure. These variants keep at most
 `capacity` pending results, with `0` treated as `1`, and pause delivery while
 the receiver catches up.
 
+`Filter` can narrow warm queries by systems, a legacy single `attr_prefix`,
+multiple `attr_prefixes`, exact `attrs`, derivation `names`, and exact
+`drv_paths`, plus attr-path `include_patterns` and `exclude_patterns` using `*`
+and `?` wildcards. Multiple populated filter fields are combined as
+intersections.
+
 Serializing `evix::Event` directly with serde preserves the Rust enum shape,
 such as `{ "derivation": { ... } }` or `{ "attr_set": { ... } }`. Use
 `evix::json::event_value` or `evix::json::event_line` when you want the

--- a/crates/evix-cli/src/args.rs
+++ b/crates/evix-cli/src/args.rs
@@ -539,7 +539,7 @@ fn pairs(values: Vec<Pair>) -> Vec<(String, String)> {
 
 fn filter(systems: Vec<String>, prefixes: Vec<String>) -> Filter {
   Filter {
-    systems:     (!systems.is_empty()).then_some(systems),
+    systems: (!systems.is_empty()).then_some(systems),
     attr_prefix: (!prefixes.is_empty()).then(|| {
       prefixes
         .into_iter()
@@ -552,6 +552,7 @@ fn filter(systems: Vec<String>, prefixes: Vec<String>) -> Filter {
         })
         .collect()
     }),
+    ..Filter::default()
   }
 }
 

--- a/crates/evix-cli/src/main.rs
+++ b/crates/evix-cli/src/main.rs
@@ -150,6 +150,8 @@ fn run_daemon_request(mut stream: UnixStream, request: &Request) -> Result<()> {
   writeln!(stream)?;
   stream.flush()?;
 
+  let expect_done = !matches!(request, Request::Watch { .. });
+  let mut saw_done = false;
   let reader = BufReader::new(stream);
   for line in reader.lines() {
     let line = line?;
@@ -161,9 +163,16 @@ fn run_daemon_request(mut stream: UnixStream, request: &Request) -> Result<()> {
         println!("{}", evix_json::event_line(&event))
       },
       Response::Diff { diff } => println!("{}", evix_json::diff_line(&diff)),
-      Response::Done => break,
+      Response::Done => {
+        saw_done = true;
+        break;
+      },
       Response::Error { message } => bail!("{message}"),
     }
+  }
+
+  if expect_done && !saw_done {
+    bail!("daemon closed connection before completing request");
   }
 
   Ok(())
@@ -229,4 +238,45 @@ fn init_tracing_subscriber(verbosity: Verbosity) {
         .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new(level)),
     )
     .init();
+}
+
+#[cfg(test)]
+mod tests {
+  use std::thread;
+
+  use super::*;
+
+  #[test]
+  fn finite_daemon_request_rejects_eof_before_done() {
+    let (client, server) = UnixStream::pair().unwrap();
+    let handle = thread::spawn(move || read_request_and_close(server));
+
+    let error = run_daemon_request(
+      client,
+      &Request::query(&Config::default(), &Default::default()),
+    )
+    .unwrap_err()
+    .to_string();
+
+    assert!(
+      error.contains("daemon closed connection before completing request")
+    );
+    handle.join().unwrap();
+  }
+
+  #[test]
+  fn watch_daemon_request_allows_eof_without_done() {
+    let (client, server) = UnixStream::pair().unwrap();
+    let handle = thread::spawn(move || read_request_and_close(server));
+
+    run_daemon_request(client, &Request::watch(&Config::default())).unwrap();
+
+    handle.join().unwrap();
+  }
+
+  fn read_request_and_close(stream: UnixStream) {
+    let mut line = String::new();
+    BufReader::new(stream).read_line(&mut line).unwrap();
+    assert!(!line.trim().is_empty());
+  }
 }

--- a/crates/evix-cli/src/main.rs
+++ b/crates/evix-cli/src/main.rs
@@ -96,7 +96,10 @@ fn run_plan(plan: CommandPlan) -> Result<()> {
       daemon::run(daemon::socket_path(socket), foreground)
     },
     CommandPlan::Worker { listen } => {
-      with_runtime(evix::serve_remote_worker(&listen))
+      with_runtime(async {
+        evix::serve_remote_worker(&listen).await?;
+        Ok(())
+      })
     },
   }
 }

--- a/crates/evix-daemon/src/lib.rs
+++ b/crates/evix-daemon/src/lib.rs
@@ -143,7 +143,13 @@ fn handle_connection(
   }
 
   let request: Request =
-    serde_json::from_str(line.trim()).context("parsing daemon request")?;
+    match serde_json::from_str(line.trim()).context("parsing daemon request") {
+      Ok(request) => request,
+      Err(err) => {
+        let _ = write_response(&mut stream, &Response::error(err.to_string()));
+        return Err(err);
+      },
+    };
 
   let runtime = Builder::new_current_thread()
     .enable_io()
@@ -151,7 +157,7 @@ fn handle_connection(
     .build()
     .context("building daemon request runtime")?;
 
-  runtime.block_on(async {
+  let result = runtime.block_on(async {
     match request {
       Request::Eval { config } => {
         handle_eval(&state, &mut stream, config).await
@@ -166,7 +172,14 @@ fn handle_connection(
         handle_diff(&state, &mut stream, config).await
       },
     }
-  })
+  });
+
+  if let Err(err) = result {
+    let _ = write_response(&mut stream, &Response::error(err.to_string()));
+    return Err(err);
+  }
+
+  Ok(())
 }
 
 async fn handle_eval(
@@ -232,4 +245,41 @@ fn write_response(stream: &mut UnixStream, response: &Response) -> Result<()> {
   writeln!(stream)?;
   stream.flush()?;
   Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn missing_warm_session_returns_protocol_error() {
+    let (mut client, server) = UnixStream::pair().unwrap();
+    let state = Arc::new(DaemonState::default());
+    let handle = thread::spawn(move || {
+      handle_connection(state, server).unwrap_err().to_string()
+    });
+
+    serde_json::to_writer(
+      &mut client,
+      &Request::query(&Config::default(), &Filter::default()),
+    )
+    .unwrap();
+    writeln!(client).unwrap();
+    client.flush().unwrap();
+
+    let mut line = String::new();
+    BufReader::new(client).read_line(&mut line).unwrap();
+    let response: Response = serde_json::from_str(line.trim()).unwrap();
+
+    let Response::Error { message } = response else {
+      panic!("expected error response");
+    };
+    assert!(message.contains("no warm session for requested config"));
+    assert!(
+      handle
+        .join()
+        .unwrap()
+        .contains("no warm session for requested config")
+    );
+  }
 }

--- a/crates/evix-daemon/src/lib.rs
+++ b/crates/evix-daemon/src/lib.rs
@@ -3,7 +3,10 @@ use std::{
   env,
   fs,
   io::{BufRead, BufReader, Write},
-  os::unix::net::{UnixListener, UnixStream},
+  os::unix::{
+    fs::FileTypeExt as _,
+    net::{UnixListener, UnixStream},
+  },
   path::{Path, PathBuf},
   process,
   sync::{Arc, Mutex},
@@ -66,15 +69,7 @@ pub fn run(socket: PathBuf, foreground: bool) -> Result<()> {
     daemonize(&socket)?;
   }
 
-  if let Some(parent) = socket.parent() {
-    fs::create_dir_all(parent).with_context(|| {
-      format!("creating socket directory {}", parent.display())
-    })?;
-  }
-  if socket.exists() {
-    fs::remove_file(&socket)
-      .with_context(|| format!("removing stale socket {}", socket.display()))?;
-  }
+  prepare_socket_path(&socket)?;
 
   let listener = UnixListener::bind(&socket)
     .with_context(|| format!("binding {}", socket.display()))?;
@@ -95,6 +90,46 @@ pub fn run(socket: PathBuf, foreground: bool) -> Result<()> {
     }
   }
 
+  Ok(())
+}
+
+fn prepare_socket_path(socket: &Path) -> Result<()> {
+  if let Some(parent) = socket
+    .parent()
+    .filter(|parent| !parent.as_os_str().is_empty())
+  {
+    fs::create_dir_all(parent).with_context(|| {
+      format!("creating socket directory {}", parent.display())
+    })?;
+  }
+
+  let metadata = match fs::symlink_metadata(socket) {
+    Ok(metadata) => metadata,
+    Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+    Err(err) => {
+      return Err(err).with_context(|| {
+        format!("checking existing socket path {}", socket.display())
+      });
+    },
+  };
+
+  if !metadata.file_type().is_socket() {
+    bail!("refusing to remove non-socket path {}", socket.display());
+  }
+
+  match UnixStream::connect(socket) {
+    Ok(_) => bail!("live daemon socket already exists at {}", socket.display()),
+    Err(err) if err.kind() == std::io::ErrorKind::ConnectionRefused => {},
+    Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+    Err(err) => {
+      return Err(err).with_context(|| {
+        format!("probing existing socket {}", socket.display())
+      });
+    },
+  }
+
+  fs::remove_file(socket)
+    .with_context(|| format!("removing stale socket {}", socket.display()))?;
   Ok(())
 }
 
@@ -249,6 +284,8 @@ fn write_response(stream: &mut UnixStream, response: &Response) -> Result<()> {
 
 #[cfg(test)]
 mod tests {
+  use std::time::{SystemTime, UNIX_EPOCH};
+
   use super::*;
 
   #[test]
@@ -281,5 +318,61 @@ mod tests {
         .unwrap()
         .contains("no warm session for requested config")
     );
+  }
+
+  #[test]
+  fn socket_startup_refuses_non_socket_path() {
+    let path = unique_socket_path("regular-file");
+    fs::create_dir_all(path.parent().unwrap()).unwrap();
+    fs::write(&path, "keep").unwrap();
+
+    let error = prepare_socket_path(&path).unwrap_err().to_string();
+
+    assert!(error.contains("refusing to remove non-socket path"));
+    assert_eq!(fs::read_to_string(&path).unwrap(), "keep");
+    cleanup_socket_path(&path);
+  }
+
+  #[test]
+  fn socket_startup_reports_live_socket() {
+    let path = unique_socket_path("live-socket");
+    fs::create_dir_all(path.parent().unwrap()).unwrap();
+    let listener = UnixListener::bind(&path).unwrap();
+
+    let error = prepare_socket_path(&path).unwrap_err().to_string();
+
+    assert!(error.contains("live daemon socket already exists"));
+    assert!(path.exists());
+    drop(listener);
+    cleanup_socket_path(&path);
+  }
+
+  #[test]
+  fn socket_startup_removes_stale_socket() {
+    let path = unique_socket_path("stale-socket");
+    fs::create_dir_all(path.parent().unwrap()).unwrap();
+    drop(UnixListener::bind(&path).unwrap());
+
+    prepare_socket_path(&path).unwrap();
+
+    assert!(!path.exists());
+    cleanup_socket_path(&path);
+  }
+
+  fn unique_socket_path(name: &str) -> PathBuf {
+    let nanos = SystemTime::now()
+      .duration_since(UNIX_EPOCH)
+      .unwrap()
+      .as_nanos();
+    env::temp_dir()
+      .join(format!("evix-daemon-{name}-{}-{nanos}", process::id()))
+      .join("evix.sock")
+  }
+
+  fn cleanup_socket_path(path: &Path) {
+    let _ = fs::remove_file(path);
+    if let Some(parent) = path.parent() {
+      let _ = fs::remove_dir_all(parent);
+    }
   }
 }

--- a/crates/evix-daemon/src/lib.rs
+++ b/crates/evix-daemon/src/lib.rs
@@ -13,7 +13,7 @@ use std::{
   thread,
 };
 
-use anyhow::{Context as _, Result, bail};
+use anyhow::{Context as _, Result, anyhow, bail};
 use evix::{Config, Filter, Session};
 use evix_protocol::{Request, Response};
 use futures_util::StreamExt as _;
@@ -65,15 +65,13 @@ pub fn socket_path(flag: Option<PathBuf>) -> PathBuf {
 }
 
 pub fn run(socket: PathBuf, foreground: bool) -> Result<()> {
-  if !foreground {
-    daemonize(&socket)?;
-  }
+  let mut reporter: Box<dyn StartupReporter> = if foreground {
+    Box::new(NoopStartupReporter)
+  } else {
+    Box::new(daemonize(&socket)?)
+  };
 
-  prepare_socket_path(&socket)?;
-
-  let listener = UnixListener::bind(&socket)
-    .with_context(|| format!("binding {}", socket.display()))?;
-  info!(socket = %socket.display(), "evix daemon listening");
+  let listener = bind_listener(&socket, reporter.as_mut())?;
   let state = Arc::new(DaemonState::default());
 
   for conn in listener.incoming() {
@@ -91,6 +89,26 @@ pub fn run(socket: PathBuf, foreground: bool) -> Result<()> {
   }
 
   Ok(())
+}
+
+fn bind_listener(
+  socket: &Path,
+  reporter: &mut dyn StartupReporter,
+) -> Result<UnixListener> {
+  let listener = match prepare_socket_path(socket).and_then(|()| {
+    UnixListener::bind(socket)
+      .with_context(|| format!("binding {}", socket.display()))
+  }) {
+    Ok(listener) => listener,
+    Err(err) => {
+      let _ = reporter.error(&err);
+      return Err(err);
+    },
+  };
+
+  reporter.ready(socket)?;
+  info!(socket = %socket.display(), "evix daemon listening");
+  Ok(listener)
 }
 
 fn prepare_socket_path(socket: &Path) -> Result<()> {
@@ -133,33 +151,117 @@ fn prepare_socket_path(socket: &Path) -> Result<()> {
   Ok(())
 }
 
-fn daemonize(socket: &Path) -> Result<()> {
+trait StartupReporter {
+  fn ready(&mut self, socket: &Path) -> Result<()>;
+  fn error(&mut self, err: &anyhow::Error) -> Result<()>;
+}
+
+struct NoopStartupReporter;
+
+impl StartupReporter for NoopStartupReporter {
+  fn ready(&mut self, _socket: &Path) -> Result<()> {
+    Ok(())
+  }
+
+  fn error(&mut self, _err: &anyhow::Error) -> Result<()> {
+    Ok(())
+  }
+}
+
+struct PipeStartupReporter {
+  stream: UnixStream,
+}
+
+impl PipeStartupReporter {
+  fn new(stream: UnixStream) -> Self {
+    Self { stream }
+  }
+}
+
+impl StartupReporter for PipeStartupReporter {
+  fn ready(&mut self, _socket: &Path) -> Result<()> {
+    write_response(&mut self.stream, &Response::Done)
+  }
+
+  fn error(&mut self, err: &anyhow::Error) -> Result<()> {
+    write_response(&mut self.stream, &Response::error(err.to_string()))
+  }
+}
+
+fn daemonize(socket: &Path) -> Result<PipeStartupReporter> {
+  let (reader, writer) =
+    UnixStream::pair().context("creating daemon readiness pipe")?;
+
   let pid = unsafe { libc::fork() };
   if pid < 0 {
     bail!("fork failed");
   }
   if pid > 0 {
-    println!("{}", socket.display());
-    process::exit(0);
+    drop(writer);
+    wait_for_readiness(socket, reader);
   }
 
+  drop(reader);
+  let reporter = PipeStartupReporter::new(writer);
+
   if unsafe { libc::setsid() } < 0 {
-    bail!("setsid failed");
+    exit_after_startup_error(reporter, anyhow!("setsid failed"));
   }
 
   let pid = unsafe { libc::fork() };
   if pid < 0 {
-    bail!("second fork failed");
+    exit_after_startup_error(reporter, anyhow!("second fork failed"));
   }
   if pid > 0 {
     process::exit(0);
   }
 
   let pid_path = pid_path();
-  fs::write(&pid_path, process::id().to_string())
-    .with_context(|| format!("writing pid file {}", pid_path.display()))?;
+  if let Err(err) = fs::write(&pid_path, process::id().to_string())
+    .with_context(|| format!("writing pid file {}", pid_path.display()))
+  {
+    exit_after_startup_error(reporter, err);
+  }
 
-  Ok(())
+  Ok(reporter)
+}
+
+fn wait_for_readiness(socket: &Path, reader: UnixStream) -> ! {
+  let mut line = String::new();
+  let result = BufReader::new(reader)
+    .read_line(&mut line)
+    .context("reading daemon readiness")
+    .and_then(|_| {
+      serde_json::from_str::<Response>(line.trim())
+        .context("parsing daemon readiness")
+    });
+
+  match result {
+    Ok(Response::Done) => {
+      println!("{}", socket.display());
+      process::exit(0);
+    },
+    Ok(Response::Error { message }) => {
+      eprintln!("{message}");
+      process::exit(1);
+    },
+    Ok(other) => {
+      eprintln!("unexpected daemon readiness response: {other:?}");
+      process::exit(1);
+    },
+    Err(err) => {
+      eprintln!("{err:?}");
+      process::exit(1);
+    },
+  }
+}
+
+fn exit_after_startup_error(
+  mut reporter: PipeStartupReporter,
+  err: anyhow::Error,
+) -> ! {
+  let _ = reporter.error(&err);
+  process::exit(1);
 }
 
 fn pid_path() -> PathBuf {
@@ -359,6 +461,34 @@ mod tests {
     cleanup_socket_path(&path);
   }
 
+  #[test]
+  fn readiness_reports_bind_failure() {
+    let path = unique_socket_path("bind-failure");
+    fs::create_dir_all(path.parent().unwrap()).unwrap();
+    let path = path.parent().unwrap().join("a".repeat(200));
+    let mut reporter = RecordingStartupReporter::default();
+
+    let error = bind_listener(&path, &mut reporter).unwrap_err().to_string();
+
+    assert!(error.contains("binding"));
+    assert!(reporter.error.unwrap().contains("binding"));
+    cleanup_socket_path(&path);
+  }
+
+  #[test]
+  fn readiness_reports_successful_background_startup() {
+    let path = unique_socket_path("ready");
+    let mut reporter = RecordingStartupReporter::default();
+
+    let listener = bind_listener(&path, &mut reporter).unwrap();
+
+    assert_eq!(reporter.ready, Some(path.clone()));
+    assert!(reporter.error.is_none());
+    assert!(path.exists());
+    drop(listener);
+    cleanup_socket_path(&path);
+  }
+
   fn unique_socket_path(name: &str) -> PathBuf {
     let nanos = SystemTime::now()
       .duration_since(UNIX_EPOCH)
@@ -373,6 +503,24 @@ mod tests {
     let _ = fs::remove_file(path);
     if let Some(parent) = path.parent() {
       let _ = fs::remove_dir_all(parent);
+    }
+  }
+
+  #[derive(Default)]
+  struct RecordingStartupReporter {
+    ready: Option<PathBuf>,
+    error: Option<String>,
+  }
+
+  impl StartupReporter for RecordingStartupReporter {
+    fn ready(&mut self, socket: &Path) -> Result<()> {
+      self.ready = Some(socket.to_path_buf());
+      Ok(())
+    }
+
+    fn error(&mut self, err: &anyhow::Error) -> Result<()> {
+      self.error = Some(err.to_string());
+      Ok(())
     }
   }
 }

--- a/crates/evix/Cargo.toml
+++ b/crates/evix/Cargo.toml
@@ -29,3 +29,8 @@ tracing.workspace         = true
 
 [build-dependencies]
 capnpc.workspace = true
+
+[[test]]
+name = "session"
+path = "tests/session.rs"
+harness = false

--- a/crates/evix/src/error.rs
+++ b/crates/evix/src/error.rs
@@ -1,0 +1,60 @@
+use std::{error, fmt};
+
+/// Error type returned by Evix's public library APIs.
+#[derive(Debug)]
+#[non_exhaustive]
+pub enum Error {
+  /// `Session::stream` was requested after the single-use stream had already
+  /// started or completed.
+  SessionStreamConsumed,
+  /// A warm-graph operation was requested before initial evaluation completed.
+  InitialEvaluationIncomplete { operation: &'static str },
+  /// A session operation requires completion, but evaluation is still running.
+  SessionStillEvaluating,
+  /// Initial evaluation failed and the stored error is being reported again.
+  EvaluationFailed { message: String },
+  /// A background task could not be spawned because no Tokio runtime was
+  /// active.
+  RuntimeUnavailable { message: String },
+  /// An internal evaluator, worker, I/O, serialization, or protocol error.
+  Internal { message: String },
+}
+
+/// Result type returned by Evix's public library APIs.
+pub type Result<T> = std::result::Result<T, Error>;
+
+impl Error {
+  pub(crate) fn internal(err: anyhow::Error) -> Self {
+    Self::Internal {
+      message: err.to_string(),
+    }
+  }
+}
+
+impl fmt::Display for Error {
+  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    match self {
+      Self::SessionStreamConsumed => {
+        write!(f, "session stream has already been consumed")
+      },
+      Self::InitialEvaluationIncomplete { operation } => {
+        write!(
+          f,
+          "Session::{operation} requires a completed initial evaluation"
+        )
+      },
+      Self::SessionStillEvaluating => write!(f, "session is still evaluating"),
+      Self::EvaluationFailed { message }
+      | Self::RuntimeUnavailable { message }
+      | Self::Internal { message } => f.write_str(message),
+    }
+  }
+}
+
+impl error::Error for Error {}
+
+impl From<anyhow::Error> for Error {
+  fn from(err: anyhow::Error) -> Self {
+    Self::internal(err)
+  }
+}

--- a/crates/evix/src/eval.rs
+++ b/crates/evix/src/eval.rs
@@ -306,7 +306,7 @@ fn read_constituents(value: &Value<'_>) -> Option<Vec<String>> {
 fn read_input_drvs(
   store: &Store,
   drv_path: &StorePath,
-) -> BTreeMap<String, serde_json::Value> {
+) -> BTreeMap<String, Vec<String>> {
   let mut map = BTreeMap::new();
   let drv = match store.read_derivation(drv_path) {
     Ok(drv) => drv,
@@ -352,13 +352,18 @@ fn read_input_drvs(
     } else {
       format!("{store_dir}/{key}")
     };
-    let outputs = value
-      .get("outputs")
-      .cloned()
-      .unwrap_or_else(|| value.clone());
+    let Some(outputs) = input_drv_outputs(value) else {
+      warn!(drv_path = %full_path, "failed to parse inputDrvs outputs");
+      continue;
+    };
     map.insert(full_path, outputs);
   }
   map
+}
+
+fn input_drv_outputs(value: &serde_json::Value) -> Option<Vec<String>> {
+  let outputs = value.get("outputs").unwrap_or(value);
+  serde_json::from_value(outputs.clone()).ok()
 }
 
 /// Collect each output's store path from a derivation value.

--- a/crates/evix/src/json.rs
+++ b/crates/evix/src/json.rs
@@ -25,7 +25,11 @@ pub fn derivation_value(d: &Derivation) -> Json {
     obj.insert("meta".into(), meta.clone());
   }
   if !d.input_drvs.is_empty() {
-    let drvs: Map<String, Json> = d.input_drvs.clone().into_iter().collect();
+    let drvs: Map<String, Json> = d
+      .input_drvs
+      .iter()
+      .map(|(drv, outputs)| (drv.clone(), json!(outputs)))
+      .collect();
     obj.insert("inputDrvs".into(), Json::Object(drvs));
   }
   if let Some(constituents) = &d.constituents {
@@ -126,9 +130,14 @@ fn parse_derivation(value: Json) -> Result<Derivation> {
     .map(|drvs| {
       drvs
         .iter()
-        .map(|(path, value)| (path.clone(), value.clone()))
-        .collect::<BTreeMap<_, _>>()
+        .map(|(path, value)| {
+          serde_json::from_value::<Vec<String>>(value.clone())
+            .map(|outputs| (path.clone(), outputs))
+        })
+        .collect::<std::result::Result<BTreeMap<_, _>, _>>()
     })
+    .transpose()
+    .context("parsing inputDrvs")?
     .unwrap_or_default();
   let constituents = value
     .get("constituents")
@@ -174,13 +183,17 @@ fn string_vec_field(value: &Json, name: &str) -> Result<Vec<String>> {
 
 #[cfg(test)]
 mod tests {
-  use super::parse_event_line;
-  use crate::Event;
+  use std::collections::BTreeMap;
+
+  use serde_json::json;
+
+  use super::{event_value, parse_event_line};
+  use crate::{Derivation, Event};
 
   #[test]
   fn parses_flat_derivation_event() {
     let event = parse_event_line(
-      r#"{"attr":"pkg","attrPath":["pkg"],"name":"pkg","system":"x86_64-linux","drvPath":"/nix/store/pkg.drv","outputs":{"out":null},"gcRootError":"link failed"}"#,
+      r#"{"attr":"pkg","attrPath":["pkg"],"name":"pkg","system":"x86_64-linux","drvPath":"/nix/store/pkg.drv","outputs":{"out":null},"inputDrvs":{"/nix/store/input.drv":["out"]},"gcRootError":"link failed"}"#,
     )
     .unwrap();
 
@@ -190,7 +203,70 @@ mod tests {
     assert_eq!(drv.attr, "pkg");
     assert_eq!(drv.system, "x86_64-linux");
     assert_eq!(drv.outputs.get("out"), Some(&None));
+    assert_eq!(
+      drv.input_drvs.get("/nix/store/input.drv"),
+      Some(&vec!["out".to_string()])
+    );
     assert_eq!(drv.gc_root_error.as_deref(), Some("link failed"));
+  }
+
+  #[test]
+  fn cli_event_value_flattens_derivation_event() {
+    let event = Event::Derivation(Derivation {
+      attr:          "pkg".into(),
+      attr_path:     vec!["pkg".into()],
+      name:          "pkg".into(),
+      system:        "x86_64-linux".into(),
+      drv_path:      "/nix/store/pkg.drv".into(),
+      outputs:       BTreeMap::from([("out".into(), None)]),
+      meta:          None,
+      input_drvs:    BTreeMap::from([("/nix/store/input.drv".into(), vec![
+        "out".into(),
+      ])]),
+      constituents:  None,
+      gc_root_error: None,
+    });
+
+    assert_eq!(
+      event_value(&event),
+      json!({
+        "attr": "pkg",
+        "attrPath": ["pkg"],
+        "name": "pkg",
+        "system": "x86_64-linux",
+        "drvPath": "/nix/store/pkg.drv",
+        "outputs": {"out": null},
+        "inputDrvs": {"/nix/store/input.drv": ["out"]}
+      })
+    );
+  }
+
+  #[test]
+  fn serde_event_shape_is_not_cli_flat_shape() {
+    let event = Event::AttrSet {
+      attr:      "packages".into(),
+      attr_path: vec!["packages".into()],
+      attrs:     vec!["hello".into()],
+    };
+
+    assert_eq!(
+      serde_json::to_value(&event).unwrap(),
+      json!({
+        "attr_set": {
+          "attr": "packages",
+          "attr_path": ["packages"],
+          "attrs": ["hello"]
+        }
+      })
+    );
+    assert_eq!(
+      event_value(&event),
+      json!({
+        "attr": "packages",
+        "attrPath": ["packages"],
+        "attrs": ["hello"]
+      })
+    );
   }
 
   #[test]

--- a/crates/evix/src/lib.rs
+++ b/crates/evix/src/lib.rs
@@ -3,6 +3,7 @@ use std::{collections::BTreeMap, env, path::PathBuf};
 use serde::{Deserialize, Serialize};
 
 mod async_master;
+mod error;
 mod eval;
 pub mod json;
 mod remote_proto;
@@ -21,6 +22,7 @@ mod worker_capnp {
   include!(concat!(env!("OUT_DIR"), "/worker_capnp.rs"));
 }
 
+pub use error::{Error, Result};
 pub use session::Session;
 
 /// Environment variable used to distinguish worker subprocesses spawned by a
@@ -101,6 +103,144 @@ impl Default for Config {
       nix_options:     Vec::new(),
       remotes:         Vec::new(),
     }
+  }
+}
+
+impl Config {
+  /// Create a config that evaluates a Nix expression string.
+  pub fn expr(expr: impl Into<String>) -> Self {
+    Self {
+      input: Input::Expr(expr.into()),
+      ..Self::default()
+    }
+  }
+
+  /// Create a config that evaluates a Nix file path.
+  pub fn file(path: impl Into<PathBuf>) -> Self {
+    Self {
+      input: Input::File(path.into()),
+      ..Self::default()
+    }
+  }
+
+  /// Create a config that evaluates a flake reference.
+  pub fn flake(reference: impl Into<String>) -> Self {
+    Self {
+      input: Input::Flake(reference.into()),
+      ..Self::default()
+    }
+  }
+
+  /// Start a chainable builder from this config.
+  pub fn builder(self) -> ConfigBuilder {
+    ConfigBuilder { config: self }
+  }
+}
+
+/// Chainable builder for [`Config`].
+#[derive(Debug, Clone)]
+pub struct ConfigBuilder {
+  config: Config,
+}
+
+impl ConfigBuilder {
+  /// Start a builder for a Nix expression input.
+  pub fn expr(expr: impl Into<String>) -> Self {
+    Config::expr(expr).builder()
+  }
+
+  /// Start a builder for a Nix file input.
+  pub fn file(path: impl Into<PathBuf>) -> Self {
+    Config::file(path).builder()
+  }
+
+  /// Start a builder for a flake reference input.
+  pub fn flake(reference: impl Into<String>) -> Self {
+    Config::flake(reference).builder()
+  }
+
+  pub fn force_recurse(mut self, enabled: bool) -> Self {
+    self.config.force_recurse = enabled;
+    self
+  }
+
+  pub fn gc_roots_dir(mut self, path: impl Into<PathBuf>) -> Self {
+    self.config.gc_roots_dir = Some(path.into());
+    self
+  }
+
+  pub fn workers(mut self, workers: usize) -> Self {
+    self.config.workers = workers;
+    self
+  }
+
+  pub fn max_memory_size(mut self, size: usize) -> Self {
+    self.config.max_memory_size = size;
+    self
+  }
+
+  pub fn meta(mut self, enabled: bool) -> Self {
+    self.config.meta = enabled;
+    self
+  }
+
+  pub fn show_input_drvs(mut self, enabled: bool) -> Self {
+    self.config.show_input_drvs = enabled;
+    self
+  }
+
+  pub fn auto_arg_expr(
+    mut self,
+    name: impl Into<String>,
+    value: impl Into<String>,
+  ) -> Self {
+    self
+      .config
+      .auto_args
+      .push((name.into(), AutoArg::Expr(value.into())));
+    self
+  }
+
+  pub fn auto_arg_str(
+    mut self,
+    name: impl Into<String>,
+    value: impl Into<String>,
+  ) -> Self {
+    self
+      .config
+      .auto_args
+      .push((name.into(), AutoArg::Str(value.into())));
+    self
+  }
+
+  pub fn override_input(
+    mut self,
+    name: impl Into<String>,
+    reference: impl Into<String>,
+  ) -> Self {
+    self
+      .config
+      .override_inputs
+      .push((name.into(), reference.into()));
+    self
+  }
+
+  pub fn nix_option(
+    mut self,
+    key: impl Into<String>,
+    value: impl Into<String>,
+  ) -> Self {
+    self.config.nix_options.push((key.into(), value.into()));
+    self
+  }
+
+  pub fn remote(mut self, remote: Remote) -> Self {
+    self.config.remotes.push(remote);
+    self
+  }
+
+  pub fn build(self) -> Config {
+    self.config
   }
 }
 
@@ -201,11 +341,16 @@ impl Event {
 ///
 /// Reads a typed setup message from stdin, then processes attribute paths
 /// requested by the master process.
-pub fn run_worker() -> anyhow::Result<()> {
-  tokio::runtime::Builder::new_current_thread()
+pub fn run_worker() -> Result<()> {
+  let runtime = tokio::runtime::Builder::new_current_thread()
     .enable_io()
-    .build()?
-    .block_on(worker::run())
+    .build()
+    .map_err(|err| {
+      Error::Internal {
+        message: err.to_string(),
+      }
+    })?;
+  runtime.block_on(worker::run()).map_err(Error::from)
 }
 
 /// Run the worker protocol when this process was spawned as an Evix worker.
@@ -213,7 +358,7 @@ pub fn run_worker() -> anyhow::Result<()> {
 /// Call this near the start of an embedding binary's `main`. If it returns
 /// `Ok(true)`, the process was a worker subprocess and the caller should return
 /// from `main` immediately.
-pub fn run_worker_if_requested() -> anyhow::Result<bool> {
+pub fn run_worker_if_requested() -> Result<bool> {
   if env::var_os(WORKER_ENV).is_none() {
     return Ok(false);
   }
@@ -223,6 +368,65 @@ pub fn run_worker_if_requested() -> anyhow::Result<bool> {
 }
 
 /// Serve remote evaluation workers over Cap'n Proto stream framing.
-pub async fn serve_remote_worker(addr: &str) -> anyhow::Result<()> {
-  remote_worker::serve(addr).await
+pub async fn serve_remote_worker(addr: &str) -> Result<()> {
+  remote_worker::serve(addr).await.map_err(Error::from)
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn config_constructors_set_input_and_defaults() {
+    let expr = Config::expr("{}");
+    let Input::Expr(value) = expr.input else {
+      panic!("expected expr input");
+    };
+    assert_eq!(value, "{}");
+    assert_eq!(expr.workers, Config::default().workers);
+
+    let file = Config::file("default.nix");
+    let Input::File(path) = file.input else {
+      panic!("expected file input");
+    };
+    assert_eq!(path, PathBuf::from("default.nix"));
+
+    let flake = Config::flake(".#checks");
+    let Input::Flake(reference) = flake.input else {
+      panic!("expected flake input");
+    };
+    assert_eq!(reference, ".#checks");
+  }
+
+  #[test]
+  fn config_builder_sets_library_options() {
+    let config = ConfigBuilder::flake(".#hydraJobs")
+      .workers(4)
+      .max_memory_size(1024)
+      .meta(true)
+      .show_input_drvs(true)
+      .force_recurse(true)
+      .gc_roots_dir("gcroots")
+      .auto_arg_expr("pkgs", "import <nixpkgs> {}")
+      .auto_arg_str("system", "x86_64-linux")
+      .override_input("nixpkgs", "github:NixOS/nixpkgs/nixos-unstable")
+      .nix_option("allow-import-from-derivation", "false")
+      .remote(Remote {
+        endpoint: "127.0.0.1:9000".into(),
+        systems:  vec!["x86_64-linux".into()],
+        workers:  2,
+      })
+      .build();
+
+    assert_eq!(config.workers, 4);
+    assert_eq!(config.max_memory_size, 1024);
+    assert!(config.meta);
+    assert!(config.show_input_drvs);
+    assert!(config.force_recurse);
+    assert_eq!(config.gc_roots_dir, Some(PathBuf::from("gcroots")));
+    assert_eq!(config.auto_args.len(), 2);
+    assert_eq!(config.override_inputs.len(), 1);
+    assert_eq!(config.nix_options.len(), 1);
+    assert_eq!(config.remotes.len(), 1);
+  }
 }

--- a/crates/evix/src/lib.rs
+++ b/crates/evix/src/lib.rs
@@ -268,9 +268,10 @@ pub struct Derivation {
   pub meta:          Option<serde_json::Value>,
   /// Input derivations keyed by `.drv` store path, present only when
   /// [`Config::show_input_drvs`] is set. The value is the output-name list for
-  /// that derivation input (e.g., `["out"]`).
+  /// that derivation input (e.g., `["out"]`). Serialized as the CLI-compatible
+  /// `inputDrvs` object.
   #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
-  pub input_drvs:    BTreeMap<String, serde_json::Value>,
+  pub input_drvs:    BTreeMap<String, Vec<String>>,
   /// Constituent attribute names for an aggregate job (Hydra
   /// `constituents`), present only when the derivation declares them.
   #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -305,6 +306,12 @@ pub struct Filter {
 }
 
 /// Event produced while traversing a Nix expression.
+///
+/// Direct serde serialization preserves this enum shape, e.g.
+/// `{ "derivation": { ... } }`, `{ "attr_set": { ... } }`, or
+/// `{ "error": { ... } }`. The CLI NDJSON format is intentionally flattened
+/// for compatibility with `nix-eval-jobs`; use [`json::event_value`] or
+/// [`json::event_line`] for that flattened shape.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum Event {

--- a/crates/evix/src/lib.rs
+++ b/crates/evix/src/lib.rs
@@ -1,4 +1,4 @@
-use std::{collections::BTreeMap, path::PathBuf};
+use std::{collections::BTreeMap, env, path::PathBuf};
 
 use serde::{Deserialize, Serialize};
 
@@ -25,7 +25,7 @@ pub use session::Session;
 
 /// Environment variable used to distinguish worker subprocesses spawned by a
 /// [`Session`]. A binary that re-executes itself to host workers should check
-/// this variable and call [`run_worker`] when it is set.
+/// this variable and enter the worker protocol when it is set.
 pub const WORKER_ENV: &str = "EVIX_WORKER";
 
 /// Input source for a Nix evaluation.
@@ -206,6 +206,20 @@ pub fn run_worker() -> anyhow::Result<()> {
     .enable_io()
     .build()?
     .block_on(worker::run())
+}
+
+/// Run the worker protocol when this process was spawned as an Evix worker.
+///
+/// Call this near the start of an embedding binary's `main`. If it returns
+/// `Ok(true)`, the process was a worker subprocess and the caller should return
+/// from `main` immediately.
+pub fn run_worker_if_requested() -> anyhow::Result<bool> {
+  if env::var_os(WORKER_ENV).is_none() {
+    return Ok(false);
+  }
+
+  run_worker()?;
+  Ok(true)
 }
 
 /// Serve remote evaluation workers over Cap'n Proto stream framing.

--- a/crates/evix/src/lib.rs
+++ b/crates/evix/src/lib.rs
@@ -301,8 +301,30 @@ pub struct Diff {
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Filter {
-  pub systems:     Option<Vec<String>>,
-  pub attr_prefix: Option<Vec<String>>,
+  /// Match derivations whose `system` is one of these values.
+  pub systems:          Option<Vec<String>>,
+  /// Backwards-compatible single attribute-path prefix.
+  pub attr_prefix:      Option<Vec<String>>,
+  /// Match derivations whose attribute path starts with any listed prefix.
+  #[serde(default, skip_serializing_if = "Option::is_none")]
+  pub attr_prefixes:    Option<Vec<Vec<String>>>,
+  /// Match derivations whose attribute path exactly equals any listed path.
+  #[serde(default, skip_serializing_if = "Option::is_none")]
+  pub attrs:            Option<Vec<Vec<String>>>,
+  /// Match derivations whose `name` is one of these values.
+  #[serde(default, skip_serializing_if = "Option::is_none")]
+  pub names:            Option<Vec<String>>,
+  /// Match derivations whose `.drv` path is one of these values.
+  #[serde(default, skip_serializing_if = "Option::is_none")]
+  pub drv_paths:        Option<Vec<String>>,
+  /// Match derivations whose rendered attr path matches any wildcard pattern.
+  /// `*` matches any string and `?` matches one character.
+  #[serde(default, skip_serializing_if = "Option::is_none")]
+  pub include_patterns: Option<Vec<String>>,
+  /// Exclude derivations whose rendered attr path matches any wildcard
+  /// pattern. `*` matches any string and `?` matches one character.
+  #[serde(default, skip_serializing_if = "Option::is_none")]
+  pub exclude_patterns: Option<Vec<String>>,
 }
 
 /// Event produced while traversing a Nix expression.

--- a/crates/evix/src/remote_proto.rs
+++ b/crates/evix/src/remote_proto.rs
@@ -340,10 +340,10 @@ fn set_derivation(
   let mut input_drvs = builder
     .reborrow()
     .init_input_drvs(derivation.input_drvs.len() as u32);
-  for (index, (drv_path, value)) in derivation.input_drvs.iter().enumerate() {
+  for (index, (drv_path, outputs)) in derivation.input_drvs.iter().enumerate() {
     let mut input_drv = input_drvs.reborrow().get(index as u32);
     input_drv.set_drv_path(drv_path);
-    input_drv.set_value_json(&serde_json::to_string(value)?);
+    input_drv.set_value_json(&serde_json::to_string(outputs)?);
   }
 
   match &derivation.constituents {
@@ -385,8 +385,10 @@ fn read_derivation(
     let input_drv = input_drvs.get(index);
     input_drv_map.insert(
       input_drv.get_drv_path()?.to_string()?,
-      serde_json::from_str(input_drv.get_value_json()?.to_str()?)
-        .context("parsing inputDrv JSON value")?,
+      serde_json::from_str::<Vec<String>>(
+        input_drv.get_value_json()?.to_str()?,
+      )
+      .context("parsing inputDrv outputs")?,
     );
   }
 

--- a/crates/evix/src/run.rs
+++ b/crates/evix/src/run.rs
@@ -1,4 +1,7 @@
-use std::sync::{Arc, atomic::AtomicBool};
+use std::{
+  future::Future,
+  sync::{Arc, atomic::AtomicBool},
+};
 
 use anyhow::Result;
 
@@ -23,6 +26,26 @@ where
     accumulator.record(&event);
     let result = on_event(event);
     async move { result }
+  })
+  .await?;
+
+  Ok((accumulator.graph, accumulator.errors))
+}
+
+pub async fn evaluate_async<F, Fut>(
+  config: Config,
+  cancel: Arc<AtomicBool>,
+  mut on_event: F,
+) -> Result<(EvalGraph, Vec<EvalError>)>
+where
+  F: FnMut(Event) -> Fut,
+  Fut: Future<Output = Result<()>>,
+{
+  let mut accumulator = EvalAccumulator::default();
+
+  crate::async_master::run(config, Arc::clone(&cancel), |event| {
+    accumulator.record(&event);
+    on_event(event)
   })
   .await?;
 

--- a/crates/evix/src/session.rs
+++ b/crates/evix/src/session.rs
@@ -7,7 +7,7 @@ use std::{
   },
 };
 
-use anyhow::{Result, anyhow, bail};
+use anyhow::{Result as AnyhowResult, anyhow};
 use futures_channel::mpsc as futures_mpsc;
 use futures_core::Stream;
 use tokio::sync::{Notify, RwLock};
@@ -17,8 +17,10 @@ use crate::{
   Config,
   Derivation,
   Diff,
+  Error,
   Event,
   Filter,
+  Result,
   run,
   state::{WarmState, diff_graphs, matches_filter},
   watch,
@@ -64,9 +66,7 @@ impl Session {
     let (tx, rx) = futures_mpsc::unbounded();
 
     if !self.start_initial_evaluation() {
-      let _ = tx.unbounded_send(Err(anyhow!(
-        "session stream has already been consumed"
-      )));
+      let _ = tx.unbounded_send(Err(Error::SessionStreamConsumed));
       return rx;
     }
 
@@ -99,7 +99,7 @@ impl Session {
         {
           let message = err.to_string();
           record_initial_error(&state, &completed, &initial, message).await;
-          let _ = tx.unbounded_send(Err(err));
+          let _ = tx.unbounded_send(Err(Error::from(err)));
         } else {
           finish_initial_evaluation(&initial);
         }
@@ -144,7 +144,7 @@ impl Session {
         {
           let message = err.to_string();
           record_initial_error(&state, &completed, &initial, message).await;
-          let _ = tx.unbounded_send(Err(err));
+          let _ = tx.unbounded_send(Err(Error::from(err)));
           return;
         } else if start_initial {
           finish_initial_evaluation(&initial);
@@ -153,7 +153,7 @@ impl Session {
         if let Err(err) =
           watch::watch_loop(config, cancel, state, completed, tx.clone()).await
         {
-          let _ = tx.unbounded_send(Err(err));
+          let _ = tx.unbounded_send(Err(Error::from(err)));
         }
       },
       spawn_state,
@@ -173,7 +173,9 @@ impl Session {
   ) -> Result<Vec<Derivation>> {
     let guard = self.state.read().await;
     if !guard.completed {
-      bail!("Session::query_snapshot requires a completed initial evaluation");
+      return Err(Error::InitialEvaluationIncomplete {
+        operation: "query_snapshot",
+      });
     }
     Ok(
       guard
@@ -195,7 +197,9 @@ impl Session {
     let previous = {
       let guard = self.state.read().await;
       if !guard.completed {
-        bail!("Session::diff_once requires a completed initial evaluation");
+        return Err(Error::InitialEvaluationIncomplete {
+          operation: "diff_once",
+        });
       }
       guard.graph.clone()
     };
@@ -217,15 +221,23 @@ impl Session {
     self.state.read().await.completed
   }
 
+  /// Request cancellation of this session's active evaluation or watch loop.
+  pub fn cancel(&self) {
+    self.cancel.store(true, Ordering::Relaxed);
+    self.completed.notify_waiters();
+  }
+
   pub async fn require_completed(&self) -> Result<()> {
     let state = self.state.read().await;
     if state.completed {
       return Ok(());
     }
     if let Some(error) = &state.error {
-      bail!("{error}");
+      return Err(Error::EvaluationFailed {
+        message: error.clone(),
+      });
     }
-    bail!("session is still evaluating")
+    Err(Error::SessionStillEvaluating)
   }
 
   fn start_initial_evaluation(&self) -> bool {
@@ -249,9 +261,9 @@ async fn evaluate_initial<F>(
   state: Arc<RwLock<WarmState>>,
   completed: Arc<Notify>,
   on_event: F,
-) -> Result<()>
+) -> AnyhowResult<()>
 where
-  F: FnMut(Event) -> Result<()> + Send + 'static,
+  F: FnMut(Event) -> AnyhowResult<()> + Send + 'static,
 {
   debug!("starting session evaluation");
   let result = run::evaluate(config, Arc::clone(&cancel), on_event).await;
@@ -312,20 +324,23 @@ fn spawn_session_task<T: Send + 'static>(
       }
       finish_initial_evaluation(&initial);
       completed.notify_waiters();
-      let _ = tx.unbounded_send(Err(anyhow!(message)));
+      let _ = tx.unbounded_send(Err(Error::RuntimeUnavailable {
+        message: message.into(),
+      }));
     },
   }
 }
 
 impl Drop for Session {
   fn drop(&mut self) {
-    self.cancel.store(true, Ordering::Relaxed);
-    self.completed.notify_waiters();
+    self.cancel();
   }
 }
 
 #[cfg(test)]
 mod tests {
+  use futures_util::StreamExt as _;
+
   use super::*;
 
   #[test]
@@ -358,5 +373,56 @@ mod tests {
         .as_deref(),
       Some("Session streams require an active Tokio runtime")
     );
+  }
+
+  #[test]
+  fn query_before_initial_eval_uses_matchable_error() {
+    let runtime = tokio::runtime::Builder::new_current_thread()
+      .build()
+      .unwrap();
+
+    let error = runtime.block_on(async {
+      let session = Session::open(Config::default()).await.unwrap();
+      session.query_snapshot(Filter::default()).await.unwrap_err()
+    });
+
+    assert!(matches!(error, Error::InitialEvaluationIncomplete {
+      operation: "query_snapshot",
+    }));
+  }
+
+  #[test]
+  fn duplicate_stream_uses_matchable_error() {
+    let runtime = tokio::runtime::Builder::new_current_thread()
+      .build()
+      .unwrap();
+    let session = Session {
+      config:    Config::default(),
+      cancel:    Arc::new(AtomicBool::new(false)),
+      state:     Arc::new(RwLock::new(WarmState::default())),
+      completed: Arc::new(Notify::new()),
+      initial:   Arc::new(Mutex::new(InitialEvaluation::Finished)),
+    };
+    let mut stream = Box::pin(session.stream());
+
+    let error =
+      runtime.block_on(async { stream.next().await.unwrap().unwrap_err() });
+
+    assert!(matches!(error, Error::SessionStreamConsumed));
+  }
+
+  #[test]
+  fn cancel_sets_session_cancellation_flag() {
+    let session = Session {
+      config:    Config::default(),
+      cancel:    Arc::new(AtomicBool::new(false)),
+      state:     Arc::new(RwLock::new(WarmState::default())),
+      completed: Arc::new(Notify::new()),
+      initial:   Arc::new(Mutex::new(InitialEvaluation::Idle)),
+    };
+
+    session.cancel();
+
+    assert!(session.cancel.load(Ordering::Relaxed));
   }
 }

--- a/crates/evix/src/session.rs
+++ b/crates/evix/src/session.rs
@@ -10,6 +10,7 @@ use std::{
 use anyhow::{Result as AnyhowResult, anyhow};
 use futures_channel::mpsc as futures_mpsc;
 use futures_core::Stream;
+use futures_util::SinkExt as _;
 use tokio::sync::{Notify, RwLock};
 use tracing::{debug, error};
 
@@ -89,10 +90,12 @@ impl Session {
           Arc::clone(&state),
           Arc::clone(&completed),
           move |event| {
-            event_tx
-              .unbounded_send(Ok(event))
-              .map_err(|_| anyhow!("session stream receiver was dropped"))?;
-            Ok(())
+            let event_tx = event_tx.clone();
+            async move {
+              event_tx
+                .unbounded_send(Ok(event))
+                .map_err(|_| anyhow!("session stream receiver was dropped"))
+            }
           },
         )
         .await
@@ -100,6 +103,66 @@ impl Session {
           let message = err.to_string();
           record_initial_error(&state, &completed, &initial, message).await;
           let _ = tx.unbounded_send(Err(Error::from(err)));
+        } else {
+          finish_initial_evaluation(&initial);
+        }
+      },
+      spawn_state,
+      spawn_completed,
+      spawn_initial,
+    );
+
+    rx
+  }
+
+  /// Stream events with a bounded result buffer.
+  ///
+  /// When the buffer is full, evaluation waits until the receiver consumes an
+  /// item. A capacity of `0` is treated as `1`.
+  pub fn stream_bounded(
+    &self,
+    capacity: usize,
+  ) -> impl Stream<Item = Result<Event>> + '_ {
+    let (mut tx, rx) = futures_mpsc::channel(bounded_capacity(capacity));
+
+    if !self.start_initial_evaluation() {
+      let _ = tx.try_send(Err(Error::SessionStreamConsumed));
+      return rx;
+    }
+
+    let config = self.config.clone();
+    let cancel = Arc::clone(&self.cancel);
+    let state = Arc::clone(&self.state);
+    let completed = Arc::clone(&self.completed);
+    let initial = Arc::clone(&self.initial);
+    let spawn_state = Arc::clone(&state);
+    let spawn_completed = Arc::clone(&completed);
+    let spawn_initial = Arc::clone(&initial);
+
+    spawn_session_task_bounded(
+      tx.clone(),
+      async move {
+        let event_tx = tx.clone();
+        if let Err(err) = evaluate_initial(
+          config,
+          cancel,
+          Arc::clone(&state),
+          Arc::clone(&completed),
+          move |event| {
+            let mut event_tx = event_tx.clone();
+            async move {
+              event_tx
+                .send(Ok(event))
+                .await
+                .map_err(|_| anyhow!("session stream receiver was dropped"))
+            }
+          },
+        )
+        .await
+        {
+          let message = err.to_string();
+          record_initial_error(&state, &completed, &initial, message).await;
+          let _ = tx.send(Err(Error::from(err))).await;
         } else {
           finish_initial_evaluation(&initial);
         }
@@ -138,7 +201,7 @@ impl Session {
             Arc::clone(&cancel),
             Arc::clone(&state),
             Arc::clone(&completed),
-            |_| Ok(()),
+            |_| async { Ok(()) },
           )
           .await
         {
@@ -154,6 +217,66 @@ impl Session {
           watch::watch_loop(config, cancel, state, completed, tx.clone()).await
         {
           let _ = tx.unbounded_send(Err(Error::from(err)));
+        }
+      },
+      spawn_state,
+      spawn_completed,
+      spawn_initial,
+    );
+
+    rx
+  }
+
+  /// Stream diffs with a bounded result buffer.
+  ///
+  /// When the buffer is full, watch delivery waits until the receiver consumes
+  /// an item. A capacity of `0` is treated as `1`.
+  pub fn watch_bounded(
+    &self,
+    capacity: usize,
+  ) -> impl Stream<Item = Result<Diff>> + '_ {
+    let (mut tx, rx) = futures_mpsc::channel(bounded_capacity(capacity));
+    let config = self.config.clone();
+    let cancel = Arc::clone(&self.cancel);
+    let state = Arc::clone(&self.state);
+    let completed = Arc::clone(&self.completed);
+    let initial = Arc::clone(&self.initial);
+    let start_initial = self.start_initial_evaluation();
+    let spawn_state = Arc::clone(&state);
+    let spawn_completed = Arc::clone(&completed);
+    let spawn_initial = Arc::clone(&initial);
+
+    spawn_session_task_bounded(
+      tx.clone(),
+      async move {
+        if start_initial
+          && let Err(err) = evaluate_initial(
+            config.clone(),
+            Arc::clone(&cancel),
+            Arc::clone(&state),
+            Arc::clone(&completed),
+            |_| async { Ok(()) },
+          )
+          .await
+        {
+          let message = err.to_string();
+          record_initial_error(&state, &completed, &initial, message).await;
+          let _ = tx.send(Err(Error::from(err))).await;
+          return;
+        } else if start_initial {
+          finish_initial_evaluation(&initial);
+        }
+
+        if let Err(err) = watch::watch_loop_bounded(
+          config,
+          cancel,
+          state,
+          completed,
+          tx.clone(),
+        )
+        .await
+        {
+          let _ = tx.send(Err(Error::from(err))).await;
         }
       },
       spawn_state,
@@ -255,7 +378,7 @@ impl Session {
   }
 }
 
-async fn evaluate_initial<F>(
+async fn evaluate_initial<F, Fut>(
   config: Config,
   cancel: Arc<AtomicBool>,
   state: Arc<RwLock<WarmState>>,
@@ -263,10 +386,11 @@ async fn evaluate_initial<F>(
   on_event: F,
 ) -> AnyhowResult<()>
 where
-  F: FnMut(Event) -> AnyhowResult<()> + Send + 'static,
+  F: FnMut(Event) -> Fut + Send + 'static,
+  Fut: Future<Output = AnyhowResult<()>>,
 {
   debug!("starting session evaluation");
-  let result = run::evaluate(config, Arc::clone(&cancel), on_event).await;
+  let result = run::evaluate_async(config, Arc::clone(&cancel), on_event).await;
 
   match result {
     Ok((graph, errors)) => {
@@ -329,6 +453,35 @@ fn spawn_session_task<T: Send + 'static>(
       }));
     },
   }
+}
+
+fn spawn_session_task_bounded<T: Send + 'static>(
+  mut tx: futures_mpsc::Sender<Result<T>>,
+  future: impl Future<Output = ()> + Send + 'static,
+  state: Arc<RwLock<WarmState>>,
+  completed: Arc<Notify>,
+  initial: Arc<Mutex<InitialEvaluation>>,
+) {
+  match tokio::runtime::Handle::try_current() {
+    Ok(handle) => {
+      handle.spawn(future);
+    },
+    Err(_) => {
+      let message = "Session streams require an active Tokio runtime";
+      if let Ok(mut state) = state.try_write() {
+        state.error = Some(message.into());
+      }
+      finish_initial_evaluation(&initial);
+      completed.notify_waiters();
+      let _ = tx.try_send(Err(Error::RuntimeUnavailable {
+        message: message.into(),
+      }));
+    },
+  }
+}
+
+fn bounded_capacity(capacity: usize) -> usize {
+  capacity.max(1)
 }
 
 impl Drop for Session {
@@ -409,6 +562,32 @@ mod tests {
       runtime.block_on(async { stream.next().await.unwrap().unwrap_err() });
 
     assert!(matches!(error, Error::SessionStreamConsumed));
+  }
+
+  #[test]
+  fn duplicate_bounded_stream_uses_matchable_error() {
+    let runtime = tokio::runtime::Builder::new_current_thread()
+      .build()
+      .unwrap();
+    let session = Session {
+      config:    Config::default(),
+      cancel:    Arc::new(AtomicBool::new(false)),
+      state:     Arc::new(RwLock::new(WarmState::default())),
+      completed: Arc::new(Notify::new()),
+      initial:   Arc::new(Mutex::new(InitialEvaluation::Finished)),
+    };
+    let mut stream = Box::pin(session.stream_bounded(1));
+
+    let error =
+      runtime.block_on(async { stream.next().await.unwrap().unwrap_err() });
+
+    assert!(matches!(error, Error::SessionStreamConsumed));
+  }
+
+  #[test]
+  fn bounded_capacity_has_minimum_one() {
+    assert_eq!(bounded_capacity(0), 1);
+    assert_eq!(bounded_capacity(8), 8);
   }
 
   #[test]

--- a/crates/evix/src/state.rs
+++ b/crates/evix/src/state.rs
@@ -63,16 +63,81 @@ pub fn matches_filter(drv: &Derivation, filter: &Filter) -> bool {
     .systems
     .as_ref()
     .is_none_or(|systems| systems.iter().any(|system| system == &drv.system));
-  let attr_matches = filter.attr_prefix.as_ref().is_none_or(|prefix| {
-    drv.attr_path.len() >= prefix.len()
-      && drv
-        .attr_path
+  let attr_prefix_matches = filter
+    .attr_prefix
+    .as_ref()
+    .is_none_or(|prefix| attr_path_starts_with(&drv.attr_path, prefix));
+  let attr_prefixes_match =
+    filter.attr_prefixes.as_ref().is_none_or(|prefixes| {
+      prefixes
         .iter()
-        .zip(prefix)
-        .all(|(actual, expected)| actual == expected)
+        .any(|prefix| attr_path_starts_with(&drv.attr_path, prefix))
+    });
+  let attrs_match = filter.attrs.as_ref().is_none_or(|attrs| {
+    attrs.iter().any(|attr| attr.as_slice() == drv.attr_path)
   });
+  let names_match = filter
+    .names
+    .as_ref()
+    .is_none_or(|names| names.iter().any(|name| name == &drv.name));
+  let drv_paths_match = filter
+    .drv_paths
+    .as_ref()
+    .is_none_or(|paths| paths.iter().any(|path| path == &drv.drv_path));
+  let include_patterns_match =
+    filter.include_patterns.as_ref().is_none_or(|patterns| {
+      patterns
+        .iter()
+        .any(|pattern| wildcard_matches(pattern, &drv.attr))
+    });
+  let exclude_patterns_match =
+    filter.exclude_patterns.as_ref().is_none_or(|patterns| {
+      !patterns
+        .iter()
+        .any(|pattern| wildcard_matches(pattern, &drv.attr))
+    });
 
-  system_matches && attr_matches
+  system_matches
+    && attr_prefix_matches
+    && attr_prefixes_match
+    && attrs_match
+    && names_match
+    && drv_paths_match
+    && include_patterns_match
+    && exclude_patterns_match
+}
+
+fn attr_path_starts_with(attr_path: &[String], prefix: &[String]) -> bool {
+  attr_path.len() >= prefix.len()
+    && attr_path
+      .iter()
+      .zip(prefix)
+      .all(|(actual, expected)| actual == expected)
+}
+
+fn wildcard_matches(pattern: &str, value: &str) -> bool {
+  let pattern = pattern.chars().collect::<Vec<_>>();
+  let value = value.chars().collect::<Vec<_>>();
+  let mut matches = vec![vec![false; value.len() + 1]; pattern.len() + 1];
+  matches[0][0] = true;
+
+  for i in 1..=pattern.len() {
+    if pattern[i - 1] == '*' {
+      matches[i][0] = matches[i - 1][0];
+    }
+  }
+
+  for i in 1..=pattern.len() {
+    for j in 1..=value.len() {
+      matches[i][j] = match pattern[i - 1] {
+        '*' => matches[i - 1][j] || matches[i][j - 1],
+        '?' => matches[i - 1][j - 1],
+        ch => ch == value[j - 1] && matches[i - 1][j - 1],
+      };
+    }
+  }
+
+  matches[pattern.len()][value.len()]
 }
 
 #[cfg(test)]
@@ -101,13 +166,42 @@ mod tests {
   fn filter_matches_system_and_attr_prefix() {
     let drv = drv("x86_64-linux", &["hydraJobs", "release"]);
     assert!(matches_filter(&drv, &Filter {
-      systems:     Some(vec!["x86_64-linux".into()]),
+      systems: Some(vec!["x86_64-linux".into()]),
       attr_prefix: Some(vec!["hydraJobs".into()]),
+      ..Filter::default()
     },));
     assert!(!matches_filter(&drv, &Filter {
-      systems:     Some(vec!["aarch64-linux".into()]),
+      systems: Some(vec!["aarch64-linux".into()]),
       attr_prefix: Some(vec!["hydraJobs".into()]),
+      ..Filter::default()
     },));
+  }
+
+  #[test]
+  fn filter_matches_expanded_fields() {
+    let mut drv = drv("x86_64-linux", &["hydraJobs", "release"]);
+    drv.name = "release-job".into();
+    drv.drv_path = "/nix/store/release-job.drv".into();
+
+    assert!(matches_filter(&drv, &Filter {
+      attr_prefixes: Some(vec![vec!["packages".into()], vec![
+        "hydraJobs".into()
+      ]]),
+      attrs: Some(vec![vec!["hydraJobs".into(), "release".into()]]),
+      names: Some(vec!["release-job".into()]),
+      drv_paths: Some(vec!["/nix/store/release-job.drv".into()]),
+      include_patterns: Some(vec!["hydraJobs.*".into()]),
+      exclude_patterns: Some(vec!["*.debug".into()]),
+      ..Filter::default()
+    }));
+    assert!(!matches_filter(&drv, &Filter {
+      include_patterns: Some(vec!["packages.*".into()]),
+      ..Filter::default()
+    }));
+    assert!(!matches_filter(&drv, &Filter {
+      exclude_patterns: Some(vec!["hydraJobs.*".into()]),
+      ..Filter::default()
+    }));
   }
 
   #[test]

--- a/crates/evix/src/watch.rs
+++ b/crates/evix/src/watch.rs
@@ -10,6 +10,7 @@ use std::{
 
 use anyhow::{Context as _, Result as AnyhowResult, anyhow, bail};
 use futures_channel::mpsc as futures_mpsc;
+use futures_util::SinkExt as _;
 use notify::{RecommendedWatcher, RecursiveMode, Watcher};
 use tokio::{
   sync::{Notify, RwLock, mpsc as tokio_mpsc},
@@ -31,6 +32,40 @@ pub async fn watch_loop(
   state: Arc<RwLock<WarmState>>,
   completed: Arc<Notify>,
   tx: futures_mpsc::UnboundedSender<crate::Result<Diff>>,
+) -> AnyhowResult<()> {
+  watch_loop_with_sender(
+    config,
+    cancel,
+    state,
+    completed,
+    WatchSender::Unbounded(tx),
+  )
+  .await
+}
+
+pub async fn watch_loop_bounded(
+  config: Config,
+  cancel: Arc<AtomicBool>,
+  state: Arc<RwLock<WarmState>>,
+  completed: Arc<Notify>,
+  tx: futures_mpsc::Sender<crate::Result<Diff>>,
+) -> AnyhowResult<()> {
+  watch_loop_with_sender(
+    config,
+    cancel,
+    state,
+    completed,
+    WatchSender::Bounded(tx),
+  )
+  .await
+}
+
+async fn watch_loop_with_sender(
+  config: Config,
+  cancel: Arc<AtomicBool>,
+  state: Arc<RwLock<WarmState>>,
+  completed: Arc<Notify>,
+  mut tx: WatchSender,
 ) -> AnyhowResult<()> {
   wait_for_initial_evaluation(&cancel, &state, &completed).await?;
 
@@ -69,14 +104,11 @@ pub async fn watch_loop(
           state.completed = true;
           state.error = None;
         }
-        tx.unbounded_send(Ok(diff))
-          .map_err(|_| anyhow!("watch stream receiver was dropped"))?;
+        tx.send(Ok(diff)).await?;
       },
       Ok(Some(Err(err))) => {
-        tx.unbounded_send(Err(Error::from(anyhow!(
-          "filesystem watch error: {err}"
-        ))))
-        .map_err(|_| anyhow!("watch stream receiver was dropped"))?;
+        tx.send(Err(Error::from(anyhow!("filesystem watch error: {err}"))))
+          .await?;
       },
       Ok(None) => bail!("filesystem watcher disconnected"),
       Err(_) => {},
@@ -84,6 +116,27 @@ pub async fn watch_loop(
   }
 
   Ok(())
+}
+
+enum WatchSender {
+  Unbounded(futures_mpsc::UnboundedSender<crate::Result<Diff>>),
+  Bounded(futures_mpsc::Sender<crate::Result<Diff>>),
+}
+
+impl WatchSender {
+  async fn send(&mut self, item: crate::Result<Diff>) -> AnyhowResult<()> {
+    match self {
+      Self::Unbounded(tx) => {
+        tx.unbounded_send(item)
+          .map_err(|_| anyhow!("watch stream receiver was dropped"))
+      },
+      Self::Bounded(tx) => {
+        tx.send(item)
+          .await
+          .map_err(|_| anyhow!("watch stream receiver was dropped"))
+      },
+    }
+  }
 }
 
 async fn wait_for_initial_evaluation(

--- a/crates/evix/src/watch.rs
+++ b/crates/evix/src/watch.rs
@@ -8,7 +8,7 @@ use std::{
   time::Duration,
 };
 
-use anyhow::{Context as _, Result, anyhow, bail};
+use anyhow::{Context as _, Result as AnyhowResult, anyhow, bail};
 use futures_channel::mpsc as futures_mpsc;
 use notify::{RecommendedWatcher, RecursiveMode, Watcher};
 use tokio::{
@@ -19,6 +19,7 @@ use tokio::{
 use crate::{
   Config,
   Diff,
+  Error,
   Input,
   run,
   state::{WarmState, diff_graphs},
@@ -29,8 +30,8 @@ pub async fn watch_loop(
   cancel: Arc<AtomicBool>,
   state: Arc<RwLock<WarmState>>,
   completed: Arc<Notify>,
-  tx: futures_mpsc::UnboundedSender<Result<Diff>>,
-) -> Result<()> {
+  tx: futures_mpsc::UnboundedSender<crate::Result<Diff>>,
+) -> AnyhowResult<()> {
   wait_for_initial_evaluation(&cancel, &state, &completed).await?;
 
   let paths = watched_paths(&config)?;
@@ -72,8 +73,10 @@ pub async fn watch_loop(
           .map_err(|_| anyhow!("watch stream receiver was dropped"))?;
       },
       Ok(Some(Err(err))) => {
-        tx.unbounded_send(Err(anyhow!("filesystem watch error: {err}")))
-          .map_err(|_| anyhow!("watch stream receiver was dropped"))?;
+        tx.unbounded_send(Err(Error::from(anyhow!(
+          "filesystem watch error: {err}"
+        ))))
+        .map_err(|_| anyhow!("watch stream receiver was dropped"))?;
       },
       Ok(None) => bail!("filesystem watcher disconnected"),
       Err(_) => {},
@@ -87,7 +90,7 @@ async fn wait_for_initial_evaluation(
   cancel: &AtomicBool,
   state: &RwLock<WarmState>,
   completed: &Notify,
-) -> Result<()> {
+) -> AnyhowResult<()> {
   while !cancel.load(Ordering::Relaxed) {
     let notified = completed.notified();
     {
@@ -111,7 +114,7 @@ async fn debounce_watch_events(
   while watch_rx.try_recv().is_ok() {}
 }
 
-fn watched_paths(config: &Config) -> Result<Vec<PathBuf>> {
+fn watched_paths(config: &Config) -> AnyhowResult<Vec<PathBuf>> {
   match &config.input {
     Input::File(path) => Ok(vec![path.clone()]),
     Input::Expr(_) => bail!("watch requires a file or local flake input"),
@@ -119,7 +122,7 @@ fn watched_paths(config: &Config) -> Result<Vec<PathBuf>> {
   }
 }
 
-fn watched_flake_paths(reference: &str) -> Result<Vec<PathBuf>> {
+fn watched_flake_paths(reference: &str) -> AnyhowResult<Vec<PathBuf>> {
   let root = local_flake_root(reference).ok_or_else(|| {
     anyhow!("flake reference is not a local path: {reference}")
   })?;
@@ -150,7 +153,7 @@ fn local_flake_root(reference: &str) -> Option<PathBuf> {
   None
 }
 
-fn local_path_inputs(root: &Path) -> Result<Vec<PathBuf>> {
+fn local_path_inputs(root: &Path) -> AnyhowResult<Vec<PathBuf>> {
   let lock_path = root.join("flake.lock");
   let Ok(contents) = fs::read_to_string(&lock_path) else {
     return Ok(Vec::new());

--- a/crates/evix/src/worker.rs
+++ b/crates/evix/src/worker.rs
@@ -132,13 +132,15 @@ fn apply_nix_options(options: &[(String, String)]) -> Result<Option<PathBuf>> {
 fn build_eval_state(
   _ctx: &Arc<Context>,
   store: &Arc<Store>,
-  config: &WorkerConfig,
+  _config: &WorkerConfig,
 ) -> Result<EvalState> {
-  let mut builder =
-    EvalStateBuilder::new(store).context("eval state builder")?;
+  let builder = EvalStateBuilder::new(store).context("eval state builder")?;
 
   #[cfg(feature = "flake")]
-  if matches!(config.input, Input::Flake(_)) {
+  let mut builder = builder;
+
+  #[cfg(feature = "flake")]
+  if matches!(_config.input, Input::Flake(_)) {
     let fs = nix_bindings::flake::FlakeSettings::new(_ctx)
       .context("flake settings")?;
     builder = builder
@@ -264,6 +266,19 @@ fn eval_flake<'s>(
     current = next;
   }
   Ok(current)
+}
+
+#[cfg(not(feature = "flake"))]
+fn eval_flake<'s>(
+  _ctx: &Arc<Context>,
+  _state: &'s EvalState,
+  flake_ref_str: &str,
+  _override_inputs: &[(String, String)],
+) -> Result<Value<'s>> {
+  bail!(
+    "flake input {flake_ref_str:?} requires evix to be built with the \
+     \"flake\" feature"
+  )
 }
 
 /// Build an attrset from the configured `--arg` / `--argstr` pairs for

--- a/crates/evix/src/worker_process.rs
+++ b/crates/evix/src/worker_process.rs
@@ -170,6 +170,43 @@ impl WorkerProcess {
       message.push_str("\nworker stderr:\n");
       message.push_str(stderr);
     }
+    append_startup_hint(&mut message, phase);
     anyhow!(message)
+  }
+}
+
+fn append_startup_hint(message: &mut String, phase: &str) {
+  if phase != "handshake" {
+    return;
+  }
+
+  message.push_str(
+    "\nhint: if this binary embeds evix::Session, call \
+     evix::run_worker_if_requested() at process startup so EVIX_WORKER \
+     subprocesses enter the worker protocol",
+  );
+}
+
+#[cfg(test)]
+mod tests {
+  use super::append_startup_hint;
+
+  #[test]
+  fn startup_hint_mentions_worker_dispatch() {
+    let mut message = String::from("worker failed");
+
+    append_startup_hint(&mut message, "handshake");
+
+    assert!(message.contains("evix::run_worker_if_requested()"));
+    assert!(message.contains("EVIX_WORKER"));
+  }
+
+  #[test]
+  fn startup_hint_is_limited_to_handshake_failures() {
+    let mut message = String::from("worker failed");
+
+    append_startup_hint(&mut message, "event");
+
+    assert!(!message.contains("run_worker_if_requested"));
   }
 }

--- a/crates/evix/tests/session.rs
+++ b/crates/evix/tests/session.rs
@@ -1,0 +1,123 @@
+use std::process;
+
+use anyhow::{Result, anyhow};
+use evix::{Config, Error, Event, Filter, Session};
+use futures_util::StreamExt as _;
+
+const EXPR: &str = r#"
+let
+  builder = builtins.toFile "evix-test-builder.sh" ''
+    #!/bin/sh
+    echo ok > "$out"
+  '';
+  mk = name: system: builtins.derivation {
+    inherit name system builder;
+  };
+in {
+  jobs = {
+    recurseForDerivations = true;
+    hello = mk "hello-1.0" "x86_64-linux";
+    linuxOnly = mk "linux-only" "x86_64-linux";
+    arm = mk "arm-only" "aarch64-linux";
+  };
+}
+"#;
+
+fn main() {
+  if let Err(err) = run() {
+    eprintln!("{err:?}");
+    process::exit(1);
+  }
+}
+
+fn run() -> Result<()> {
+  if evix::run_worker_if_requested()? {
+    return Ok(());
+  }
+
+  tokio::runtime::Builder::new_current_thread()
+    .enable_io()
+    .enable_time()
+    .build()?
+    .block_on(async {
+      stream_query_and_diff().await?;
+      cancellation_drop_and_single_use().await?;
+      Ok(())
+    })
+}
+
+async fn stream_query_and_diff() -> Result<()> {
+  let session = Session::open(
+    Config::expr(EXPR)
+      .builder()
+      .workers(1)
+      .max_memory_size(1024)
+      .build(),
+  )
+  .await?;
+  let events = collect_events(session.stream()).await?;
+  let derivations = events
+    .into_iter()
+    .filter_map(|event| {
+      match event {
+        Event::Derivation(derivation) => Some(derivation),
+        Event::AttrSet { .. } | Event::Error(_) => None,
+      }
+    })
+    .collect::<Vec<_>>();
+
+  let hello = derivations
+    .iter()
+    .find(|derivation| derivation.attr == "jobs.hello")
+    .ok_or_else(|| anyhow!("missing jobs.hello derivation"))?;
+  let queried = session
+    .query_snapshot(Filter {
+      systems: Some(vec![hello.system.clone()]),
+      attr_prefixes: Some(vec![vec!["jobs".into()]]),
+      attrs: Some(vec![hello.attr_path.clone()]),
+      names: Some(vec![hello.name.clone()]),
+      drv_paths: Some(vec![hello.drv_path.clone()]),
+      include_patterns: Some(vec!["jobs.*".into()]),
+      exclude_patterns: Some(vec!["*.linuxOnly".into()]),
+      ..Filter::default()
+    })
+    .await?;
+
+  assert_eq!(queried.len(), 1);
+  assert_eq!(queried[0].attr, "jobs.hello");
+  assert!(session.is_completed().await);
+  session.require_completed().await?;
+
+  let diff = session.diff_once().await?;
+  assert!(diff.added.is_empty());
+  assert!(diff.removed.is_empty());
+  Ok(())
+}
+
+async fn cancellation_drop_and_single_use() -> Result<()> {
+  let session = Session::open(Config::expr("{}")).await?;
+  session.cancel();
+  let first = session.stream_bounded(1);
+  let mut second = Box::pin(session.stream());
+  let error = second
+    .next()
+    .await
+    .ok_or_else(|| anyhow!("missing duplicate stream error"))?
+    .unwrap_err();
+
+  assert!(matches!(error, Error::SessionStreamConsumed));
+  drop(second);
+  drop(first);
+  drop(session);
+  Ok(())
+}
+
+async fn collect_events(
+  stream: impl futures_core::Stream<Item = evix::Result<Event>>,
+) -> Result<Vec<Event>> {
+  let events = stream.collect::<Vec<_>>().await;
+  events
+    .into_iter()
+    .collect::<evix::Result<Vec<_>>>()
+    .map_err(Into::into)
+}


### PR DESCRIPTION
I wish this was the PR titled "evix: migrate to snix" (who the hell is coming with those names?). Alas, most of the APIs we're using from Nix are **missing in Snix**. While I work on coordinating patches, this is a general cleanup to improve the DX for those using Evix as a library. A CLI cleanup will have to follow, eventually, but this is the surface we need for Circus.